### PR TITLE
Fixed issue #19 - support highlight when selected image

### DIFF
--- a/Example/FusumaExample/Sources/FSAlbumViewCell.swift
+++ b/Example/FusumaExample/Sources/FSAlbumViewCell.swift
@@ -20,4 +20,16 @@ final class FSAlbumViewCell: UICollectionViewCell {
             self.imageView.image = image            
         }
     }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        self.selected = false
+    }
+    
+    override var selected : Bool {
+        didSet {
+            self.layer.borderColor = selected ? fusumaTintColor.CGColor : UIColor.clearColor().CGColor
+            self.layer.borderWidth = selected ? 3 : 0
+        }
+    }
 }

--- a/Sources/FSAlbumViewCell.swift
+++ b/Sources/FSAlbumViewCell.swift
@@ -20,4 +20,16 @@ final class FSAlbumViewCell: UICollectionViewCell {
             self.imageView.image = image            
         }
     }
+    
+    override func awakeFromNib() {
+        super.awakeFromNib()
+        self.selected = false
+    }
+    
+    override var selected : Bool {
+        didSet {
+            self.layer.borderColor = selected ? fusumaTintColor.CGColor : UIColor.clearColor().CGColor
+            self.layer.borderWidth = selected ? 3 : 0
+        }
+    }
 }


### PR DESCRIPTION
Now is implemented a visible frame selection for the current selected cell using the theme tint color (fusumaTintColor) as you can see here:
<img width="314" alt="captura de pantalla 2016-03-29 a las 21 07 41" src="https://cloud.githubusercontent.com/assets/15235377/14120268/4e6b63a4-f5f2-11e5-9288-6343a3b680ea.png">
