### PR TITLE
Added enhancement for keeping visible the selected picture

### DIFF
--- a/Example/FusumaExample/Sources/FSAlbumView.swift
+++ b/Example/FusumaExample/Sources/FSAlbumView.swift
@@ -283,6 +283,7 @@ final class FSAlbumView: UIView, UICollectionViewDataSource, UICollectionViewDel
             }, completion: nil)
         
         dragDirection = Direction.Up
+        collectionView.scrollToItemAtIndexPath(indexPath, atScrollPosition: .Top, animated: true)
     }
     
     

--- a/Sources/FSAlbumView.swift
+++ b/Sources/FSAlbumView.swift
@@ -283,6 +283,7 @@ final class FSAlbumView: UIView, UICollectionViewDataSource, UICollectionViewDel
             }, completion: nil)
         
         dragDirection = Direction.Up
+        collectionView.scrollToItemAtIndexPath(indexPath, atScrollPosition: .Top, animated: true)
     }
     
     


### PR DESCRIPTION
While I've being fixing the previous issues (#19 and #20) I found the need of keep visible the current selected picture, because sometimes if you press on a picture down in the scroll and you show the full collection view when the "detail view" appears again you loose the selected cell due to this scroll down that let the detail appears from the top.

With this improvement you always keep the selected square in the first line when you press on it and you will be able to continue selecting in the same line you started and never loose the place where you were selecting.
