### PR TITLE
Fast view snapshotting & improved UX

### DIFF
--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -200,7 +200,11 @@ public final class FusumaViewController: UIViewController {
     
     public override func viewWillDisappear(animated: Bool) {
         super.viewWillDisappear(animated)
-        self.stopAll()
+    }
+  
+    public override func viewDidDisappear(animated: Bool) {
+      super.viewDidDisappear(animated)
+      stopAll()
     }
 
     override public func prefersStatusBarHidden() -> Bool {
@@ -233,11 +237,11 @@ public final class FusumaViewController: UIViewController {
     @IBAction func doneButtonPressed(sender: UIButton) {
         
         let view = albumView.imageCropView
-        
+      
         UIGraphicsBeginImageContextWithOptions(view.frame.size, true, 0)
         let context = UIGraphicsGetCurrentContext()
         CGContextTranslateCTM(context, -albumView.imageCropView.contentOffset.x, -albumView.imageCropView.contentOffset.y)
-        view.layer.renderInContext(context!)
+        view.drawViewHierarchyInRect(view.bounds, afterScreenUpdates: false)
         let image = UIGraphicsGetImageFromCurrentImageContext()
         UIGraphicsEndImageContext()
         


### PR DESCRIPTION
## Small but useful changes

1) iOS 7 brought a much faster way to draw the view's hierarchy into the context. Instead of rendering the layer in the context you simply call `drawViewHierarchyInRect(_:, _:)` method on your view which does all the magic. It's really cool! 😎 

2) Using `viewWillDisappear()` method isn't quite well for user experience – stopping sessions takes time, as a result we get a delay which is noticeable enough. Such things don't make users happy, so let's change the point. 😃 

Thanks in advance! 
