### PR TITLE
hide done button when App doesn't have photosAssets access permission

### DIFF
--- a/Fusuma.xcodeproj/project.pbxproj
+++ b/Fusuma.xcodeproj/project.pbxproj
@@ -29,7 +29,7 @@
 		52412A981CA6114A0073C4BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EDDC0B3C1D04F53E009135DB /* FSVideoCameraView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FSVideoCameraView.swift; sourceTree = "<group>"; };
 		EDDC0B3D1D04F53E009135DB /* FSVideoCameraView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FSVideoCameraView.xib; sourceTree = "<group>"; };
-		EDDC0B481D0511E7009135DB /* FusumaViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FusumaViewController.swift; sourceTree = "<group>"; };
+		EDDC0B481D0511E7009135DB /* FusumaViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; indentWidth = 4; lastKnownFileType = sourcecode.swift; path = FusumaViewController.swift; sourceTree = "<group>"; tabWidth = 4; };
 		EDDC0B491D0511E7009135DB /* FusumaViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FusumaViewController.xib; sourceTree = "<group>"; };
 		EDDC0B4C1D0511F2009135DB /* FSAlbumView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FSAlbumView.swift; sourceTree = "<group>"; };
 		EDDC0B4D1D0511F2009135DB /* FSAlbumView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FSAlbumView.xib; sourceTree = "<group>"; };
@@ -60,7 +60,9 @@
 				52412A951CA6114A0073C4BE /* Fusuma */,
 				52412A941CA6114A0073C4BE /* Products */,
 			);
+			indentWidth = 4;
 			sourceTree = "<group>";
+			tabWidth = 4;
 		};
 		52412A941CA6114A0073C4BE /* Products */ = {
 			isa = PBXGroup;

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -82,6 +82,10 @@ public final class FusumaViewController: UIViewController {
     lazy var albumView  = FSAlbumView.instance()
     lazy var cameraView = FSCameraView.instance()
     lazy var videoView = FSVideoCameraView.instance()
+
+    private var hasGalleryPermission: Bool {
+        return PHPhotoLibrary.authorizationStatus() == .Authorized
+    }
     
     public weak var delegate: FusumaDelegate? = nil
     
@@ -260,7 +264,6 @@ public final class FusumaViewController: UIViewController {
     }
     
     @IBAction func doneButtonPressed(sender: UIButton) {
-        
         let view = albumView.imageCropView
 
         if fusumaCropImage {
@@ -389,6 +392,7 @@ private extension FusumaViewController {
             self.view.bringSubviewToFront(videoShotContainer)
             videoView.startCamera()
         }
+        doneButton.hidden = !hasGalleryPermission
         self.view.bringSubviewToFront(menuView)
     }
     


### PR DESCRIPTION
The 'done' button shows up when the App doesn't even have access permission, which will lead to crash with some unwrapped optional variables.
