### PR TITLE
[Breaking Changes] Various Improvements and Configurable Tabs

### DIFF
--- a/Example/FusumaExample.xcodeproj/project.pbxproj
+++ b/Example/FusumaExample.xcodeproj/project.pbxproj
@@ -12,19 +12,7 @@
 		52412AC91CA61C9F0073C4BE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 52412AC71CA61C9F0073C4BE /* Main.storyboard */; };
 		52412ACB1CA61C9F0073C4BE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52412ACA1CA61C9F0073C4BE /* Assets.xcassets */; };
 		52412ACE1CA61C9F0073C4BE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 52412ACC1CA61C9F0073C4BE /* LaunchScreen.storyboard */; };
-		D77CA2991CBBDEB300C4BAC4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D77CA28E1CBBDEB300C4BAC4 /* Assets.xcassets */; };
-		D77CA29A1CBBDEB300C4BAC4 /* FSAlbumView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77CA28F1CBBDEB300C4BAC4 /* FSAlbumView.swift */; };
-		D77CA29B1CBBDEB300C4BAC4 /* FSAlbumView.xib in Resources */ = {isa = PBXBuildFile; fileRef = D77CA2901CBBDEB300C4BAC4 /* FSAlbumView.xib */; };
-		D77CA29C1CBBDEB300C4BAC4 /* FSAlbumViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77CA2911CBBDEB300C4BAC4 /* FSAlbumViewCell.swift */; };
-		D77CA29D1CBBDEB300C4BAC4 /* FSAlbumViewCell.xib in Resources */ = {isa = PBXBuildFile; fileRef = D77CA2921CBBDEB300C4BAC4 /* FSAlbumViewCell.xib */; };
-		D77CA29E1CBBDEB300C4BAC4 /* FSCameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77CA2931CBBDEB300C4BAC4 /* FSCameraView.swift */; };
-		D77CA29F1CBBDEB300C4BAC4 /* FSCameraView.xib in Resources */ = {isa = PBXBuildFile; fileRef = D77CA2941CBBDEB300C4BAC4 /* FSCameraView.xib */; };
-		D77CA2A01CBBDEB300C4BAC4 /* FSConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77CA2951CBBDEB300C4BAC4 /* FSConstants.swift */; };
-		D77CA2A11CBBDEB300C4BAC4 /* FSImageCropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77CA2961CBBDEB300C4BAC4 /* FSImageCropView.swift */; };
-		D77CA2A21CBBDEB300C4BAC4 /* FusumaViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77CA2971CBBDEB300C4BAC4 /* FusumaViewController.swift */; };
-		D77CA2A31CBBDEB300C4BAC4 /* FusumaViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = D77CA2981CBBDEB300C4BAC4 /* FusumaViewController.xib */; };
-		EDDC0B421D04FA14009135DB /* FSVideoCameraView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EDDC0B401D04FA14009135DB /* FSVideoCameraView.swift */; };
-		EDDC0B431D04FA14009135DB /* FSVideoCameraView.xib in Resources */ = {isa = PBXBuildFile; fileRef = EDDC0B411D04FA14009135DB /* FSVideoCameraView.xib */; };
+		C9ED86741D8F6DD200E14FDF /* Fusuma.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9ED86731D8F6DD200E14FDF /* Fusuma.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -35,19 +23,7 @@
 		52412ACA1CA61C9F0073C4BE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		52412ACD1CA61C9F0073C4BE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		52412ACF1CA61C9F0073C4BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		D77CA28E1CBBDEB300C4BAC4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		D77CA28F1CBBDEB300C4BAC4 /* FSAlbumView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FSAlbumView.swift; sourceTree = "<group>"; };
-		D77CA2901CBBDEB300C4BAC4 /* FSAlbumView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FSAlbumView.xib; sourceTree = "<group>"; };
-		D77CA2911CBBDEB300C4BAC4 /* FSAlbumViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FSAlbumViewCell.swift; sourceTree = "<group>"; };
-		D77CA2921CBBDEB300C4BAC4 /* FSAlbumViewCell.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FSAlbumViewCell.xib; sourceTree = "<group>"; };
-		D77CA2931CBBDEB300C4BAC4 /* FSCameraView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FSCameraView.swift; sourceTree = "<group>"; };
-		D77CA2941CBBDEB300C4BAC4 /* FSCameraView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FSCameraView.xib; sourceTree = "<group>"; };
-		D77CA2951CBBDEB300C4BAC4 /* FSConstants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FSConstants.swift; sourceTree = "<group>"; };
-		D77CA2961CBBDEB300C4BAC4 /* FSImageCropView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FSImageCropView.swift; sourceTree = "<group>"; };
-		D77CA2971CBBDEB300C4BAC4 /* FusumaViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FusumaViewController.swift; sourceTree = "<group>"; };
-		D77CA2981CBBDEB300C4BAC4 /* FusumaViewController.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FusumaViewController.xib; sourceTree = "<group>"; };
-		EDDC0B401D04FA14009135DB /* FSVideoCameraView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FSVideoCameraView.swift; sourceTree = "<group>"; };
-		EDDC0B411D04FA14009135DB /* FSVideoCameraView.xib */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = file.xib; path = FSVideoCameraView.xib; sourceTree = "<group>"; };
+		C9ED86731D8F6DD200E14FDF /* Fusuma.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fusuma.framework; path = "../../../../Library/Developer/Xcode/DerivedData/Fusuma-fkreyenrbxxkdrakwgklfuqzzxvx/Build/Products/Debug-iphonesimulator/Fusuma.framework"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -55,6 +31,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C9ED86741D8F6DD200E14FDF /* Fusuma.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -64,6 +41,7 @@
 		52412AB71CA61C9F0073C4BE = {
 			isa = PBXGroup;
 			children = (
+				C9ED86731D8F6DD200E14FDF /* Fusuma.framework */,
 				52412AC21CA61C9F0073C4BE /* FusumaExample */,
 				52412AC11CA61C9F0073C4BE /* Products */,
 			);
@@ -80,7 +58,6 @@
 		52412AC21CA61C9F0073C4BE /* FusumaExample */ = {
 			isa = PBXGroup;
 			children = (
-				D77CA28D1CBBDEB300C4BAC4 /* Sources */,
 				52412AC31CA61C9F0073C4BE /* AppDelegate.swift */,
 				52412AC51CA61C9F0073C4BE /* ViewController.swift */,
 				52412AC71CA61C9F0073C4BE /* Main.storyboard */,
@@ -89,27 +66,6 @@
 				52412ACF1CA61C9F0073C4BE /* Info.plist */,
 			);
 			path = FusumaExample;
-			sourceTree = "<group>";
-		};
-		D77CA28D1CBBDEB300C4BAC4 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-				D77CA28E1CBBDEB300C4BAC4 /* Assets.xcassets */,
-				D77CA28F1CBBDEB300C4BAC4 /* FSAlbumView.swift */,
-				D77CA2901CBBDEB300C4BAC4 /* FSAlbumView.xib */,
-				D77CA2911CBBDEB300C4BAC4 /* FSAlbumViewCell.swift */,
-				D77CA2921CBBDEB300C4BAC4 /* FSAlbumViewCell.xib */,
-				D77CA2931CBBDEB300C4BAC4 /* FSCameraView.swift */,
-				D77CA2941CBBDEB300C4BAC4 /* FSCameraView.xib */,
-				D77CA2951CBBDEB300C4BAC4 /* FSConstants.swift */,
-				D77CA2961CBBDEB300C4BAC4 /* FSImageCropView.swift */,
-				D77CA2971CBBDEB300C4BAC4 /* FusumaViewController.swift */,
-				D77CA2981CBBDEB300C4BAC4 /* FusumaViewController.xib */,
-				EDDC0B401D04FA14009135DB /* FSVideoCameraView.swift */,
-				EDDC0B411D04FA14009135DB /* FSVideoCameraView.xib */,
-			);
-			name = Sources;
-			path = ../../Sources;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -170,14 +126,8 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				EDDC0B431D04FA14009135DB /* FSVideoCameraView.xib in Resources */,
-				D77CA29B1CBBDEB300C4BAC4 /* FSAlbumView.xib in Resources */,
-				D77CA2A31CBBDEB300C4BAC4 /* FusumaViewController.xib in Resources */,
 				52412ACE1CA61C9F0073C4BE /* LaunchScreen.storyboard in Resources */,
-				D77CA29F1CBBDEB300C4BAC4 /* FSCameraView.xib in Resources */,
 				52412ACB1CA61C9F0073C4BE /* Assets.xcassets in Resources */,
-				D77CA29D1CBBDEB300C4BAC4 /* FSAlbumViewCell.xib in Resources */,
-				D77CA2991CBBDEB300C4BAC4 /* Assets.xcassets in Resources */,
 				52412AC91CA61C9F0073C4BE /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -190,14 +140,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				52412AC61CA61C9F0073C4BE /* ViewController.swift in Sources */,
-				EDDC0B421D04FA14009135DB /* FSVideoCameraView.swift in Sources */,
-				D77CA29E1CBBDEB300C4BAC4 /* FSCameraView.swift in Sources */,
-				D77CA29C1CBBDEB300C4BAC4 /* FSAlbumViewCell.swift in Sources */,
-				D77CA29A1CBBDEB300C4BAC4 /* FSAlbumView.swift in Sources */,
-				D77CA2A01CBBDEB300C4BAC4 /* FSConstants.swift in Sources */,
-				D77CA2A21CBBDEB300C4BAC4 /* FusumaViewController.swift in Sources */,
 				52412AC41CA61C9F0073C4BE /* AppDelegate.swift in Sources */,
-				D77CA2A11CBBDEB300C4BAC4 /* FSImageCropView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/FusumaExample.xcodeproj/project.pbxproj
+++ b/Example/FusumaExample.xcodeproj/project.pbxproj
@@ -12,8 +12,22 @@
 		52412AC91CA61C9F0073C4BE /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 52412AC71CA61C9F0073C4BE /* Main.storyboard */; };
 		52412ACB1CA61C9F0073C4BE /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 52412ACA1CA61C9F0073C4BE /* Assets.xcassets */; };
 		52412ACE1CA61C9F0073C4BE /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 52412ACC1CA61C9F0073C4BE /* LaunchScreen.storyboard */; };
-		C9ED86741D8F6DD200E14FDF /* Fusuma.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C9ED86731D8F6DD200E14FDF /* Fusuma.framework */; };
+		C9ED86811D8F949100E14FDF /* Fusuma.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = C9ED867F1D8F949100E14FDF /* Fusuma.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 /* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		C9ED86821D8F949100E14FDF /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				C9ED86811D8F949100E14FDF /* Fusuma.framework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
 		52412AC01CA61C9F0073C4BE /* FusumaExample.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = FusumaExample.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -23,7 +37,7 @@
 		52412ACA1CA61C9F0073C4BE /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		52412ACD1CA61C9F0073C4BE /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		52412ACF1CA61C9F0073C4BE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		C9ED86731D8F6DD200E14FDF /* Fusuma.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Fusuma.framework; path = "../../../../Library/Developer/Xcode/DerivedData/Fusuma-fkreyenrbxxkdrakwgklfuqzzxvx/Build/Products/Debug-iphonesimulator/Fusuma.framework"; sourceTree = "<group>"; };
+		C9ED867F1D8F949100E14FDF /* Fusuma.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; name = Fusuma.framework; path = "/Users/matt/Library/Developer/Xcode/DerivedData/Fusuma-fkreyenrbxxkdrakwgklfuqzzxvx/Build/Products/Debug-iphoneos/Fusuma.framework"; sourceTree = "<absolute>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -31,7 +45,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C9ED86741D8F6DD200E14FDF /* Fusuma.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -41,7 +54,7 @@
 		52412AB71CA61C9F0073C4BE = {
 			isa = PBXGroup;
 			children = (
-				C9ED86731D8F6DD200E14FDF /* Fusuma.framework */,
+				C9ED867F1D8F949100E14FDF /* Fusuma.framework */,
 				52412AC21CA61C9F0073C4BE /* FusumaExample */,
 				52412AC11CA61C9F0073C4BE /* Products */,
 			);
@@ -78,6 +91,7 @@
 				52412ABC1CA61C9F0073C4BE /* Sources */,
 				52412ABD1CA61C9F0073C4BE /* Frameworks */,
 				52412ABE1CA61C9F0073C4BE /* Resources */,
+				C9ED86821D8F949100E14FDF /* Embed Frameworks */,
 			);
 			buildRules = (
 			);

--- a/Example/FusumaExample/ViewController.swift
+++ b/Example/FusumaExample/ViewController.swift
@@ -33,7 +33,11 @@ class ViewController: UIViewController, FusumaDelegate {
         
         // Show Fusuma
         let fusuma = FusumaViewController()
-        
+        // Try these!
+
+        // fusuma.availableModes = [.Camera, .Video]
+        // fusuma.availableModes = [.Camera]
+
         // fusumaCropImage = false
 
         fusuma.delegate = self

--- a/Example/FusumaExample/ViewController.swift
+++ b/Example/FusumaExample/ViewController.swift
@@ -33,54 +33,53 @@ class ViewController: UIViewController, FusumaDelegate {
         // Show Fusuma
         let fusuma = FusumaViewController()
         
-//        fusumaCropImage = false
-        
+        // fusumaCropImage = false
+
         fusuma.delegate = self
         self.presentViewController(fusuma, animated: true, completion: nil)
         
     }
     
     // MARK: FusumaDelegate Protocol
-    func fusumaImageSelected(image: UIImage) {
-        
+    func fusuma(fusuma: FusumaViewController, imageSelected image: UIImage) {
         print("Image selected")
         imageView.image = image
+        self.dismissViewControllerAnimated(true, completion: nil)
     }
-    
-    func fusumaVideoCompleted(withFileURL fileURL: NSURL) {
+      
+    func fusuma(fusuma: FusumaViewController, videoCompletedWithFileURL fileURL: NSURL) {
         print("video completed and output to file: \(fileURL)")
         self.fileUrlLabel.text = "file output to: \(fileURL.absoluteString)"
+        self.dismissViewControllerAnimated(true, completion: nil)
     }
+
     
-    func fusumaDismissedWithImage(image: UIImage) {
-        
-        print("Called just after dismissed FusumaViewController")
-    }
-    
-    func fusumaCameraRollUnauthorized() {
-        
+    func fusumaCameraRollUnauthorized(fusuma: FusumaViewController) {
+
+        self.dismissViewControllerAnimated(true, completion: nil)
+
         print("Camera roll unauthorized")
-        
+
         let alert = UIAlertController(title: "Access Requested", message: "Saving image needs to access your photo album", preferredStyle: .Alert)
-        
+
         alert.addAction(UIAlertAction(title: "Settings", style: .Default, handler: { (action) -> Void in
-            
-            if let url = NSURL(string:UIApplicationOpenSettingsURLString) {
-                UIApplication.sharedApplication().openURL(url)
-            }
+
+          if let url = NSURL(string:UIApplicationOpenSettingsURLString) {
+            UIApplication.sharedApplication().openURL(url)
+          }
 
         }))
-        
+
         alert.addAction(UIAlertAction(title: "Cancel", style: .Cancel, handler: { (action) -> Void in
-            
+
         }))
-        
+
         self.presentViewController(alert, animated: true, completion: nil)
     }
-    
-    func fusumaClosed() {
-     
+
+    func fusumaClosed(fusuma: FusumaViewController) {
         print("Called when the close button is pressed")
+        self.dismissViewControllerAnimated(true, completion: nil)
     }
 
 }

--- a/Example/FusumaExample/ViewController.swift
+++ b/Example/FusumaExample/ViewController.swift
@@ -7,6 +7,7 @@
 //
 
 import UIKit
+import Fusuma
 
 class ViewController: UIViewController, FusumaDelegate {
     

--- a/Example/FusumaExample/ViewController.swift
+++ b/Example/FusumaExample/ViewController.swift
@@ -41,7 +41,7 @@ class ViewController: UIViewController, FusumaDelegate {
     }
     
     // MARK: FusumaDelegate Protocol
-    func fusuma(fusuma: FusumaViewController, imageSelected image: UIImage) {
+  func fusuma(fusuma: FusumaViewController, imageSelected image: UIImage, viaMode mode: Int) {
         print("Image selected")
         imageView.image = image
         self.dismissViewControllerAnimated(true, completion: nil)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Fusuma
+# Fusuma
 
 Fusuma is a Swift library that provides an Instagram-like photo browser and a camera feature with a few line of code.  
 You can use Fusuma instead of UIImagePickerController. It also has a feature to take a square-sized photo.
@@ -51,53 +51,61 @@ github "ytakzk/Fusuma"
 ## Fusuma Usage
 Import Fusuma ```import Fusuma``` then use the following codes in some function except for viewDidLoad and give FusumaDelegate to the view controller.  
 
-```Swift
+```swift
 let fusuma = FusumaViewController()
 fusuma.delegate = self
-fusuma.hasVideo = true // If you want to let the users allow to use video.
+fusuma.availableModes = [.Library, .Camera, .Video]
+// ^ If you want to allow users to take video.
 self.presentViewController(fusuma, animated: true, completion: nil)
+```
+
+### availableModes
+
+Configure which tabs are available to the user by setting `availableModes`. The order is respected
+
+```swift
+fusuma.availableModes = [.Camera] // no tabs are shown and camera is selected
+fusuma.availableModes = [.Library, .Camera] // (default) library is selected first, camera is to the right
+fusuma.availableModes = [.Camera, .Library, .Video] // all modes
 ```
 
 #### Delegate methods
 
-```Swift
+```swift
 // Return the image which is selected from camera roll or is taken via the camera.
-func fusumaImageSelected(image: UIImage) {
-
-  print("Image selected")
+func fusuma(fusuma: FusumaViewController, imageSelected image: UIImage, viaMode mode: Int) {
+    print("Image selected! :)")
 }
 
-// Return the image but called after is dismissed.
-func fusumaDismissedWithImage(image: UIImage) {
-        
-  print("Called just after FusumaViewController is dismissed.")
+// Fusuma was closed without choosing an image.
+optional func fusumaClosed(fusuma: FusumaViewController) {
+    print("No image chosen :(")
 }
 
-func fusumaVideoCompleted(withFileURL fileURL: NSURL) {
-
-  print("Called just after a video has been selected.")
+// Called just after a video has been selected.
+func fusuma(fusuma: FusumaViewController, videoCompletedWithFileURL fileURL: NSURL) {
+    print("Video taken! :)")
 }
 
 // When camera roll is not authorized, this method is called.
-func fusumaCameraRollUnauthorized() {
-
-  print("Camera roll unauthorized")
+func fusumaCameraRollUnauthorized(fusuma: FusumaViewController) {
+  print("Camera roll unauthorized :(")
 }
 ```
 
 #### Colors
 
-```Swift
-fusumaTintColor: UIColor // tint color
-
-fusumaBackgroundColor: UIColor // background color
+```swift
+baseTintColor : UIColor   // the default tintColor
+tintColor : UIColor       // the active tintColor
+backgroundColor : UIColor // the backgroundColor
 ```
 
 #### Customize Image Output 
 You can deselect image crop mode with: 
 
-```Swift
-fusumaCropImage:Bool // default is true for cropping the image 
+```swift
+cropImage: Bool // default is true for cropping the image
 ```
 
 ## Fusuma for Xamarin
@@ -107,6 +115,10 @@ https://github.com/Cheesebaron/Chafu
 ## Author
 ytakzk  
  [http://ytakzk.me](http://ytakzk.me)
+
+## Contributors
+Shrugs
+ [https://github.com/Shrugs](https://github.com/Shrugs)
  
 ## Donation
 Your support is welcome through Bitcoin 16485BTK9EoQUqkMmSecJ9xN6E9nhW8ePd

--- a/Sources/FSAlbumView.swift
+++ b/Sources/FSAlbumView.swift
@@ -27,10 +27,10 @@ final class FSAlbumView: UIView, UICollectionViewDataSource, UICollectionViewDel
 
     override var backgroundColor: UIColor? {
         didSet {
-            if collectionView != nil {
+            if let collectionView = collectionView {
                 collectionView.backgroundColor = backgroundColor
             }
-            if imageCropView != nil {
+            if let imageCropView = imageCropView {
                 imageCropView.backgroundColor = backgroundColor
             }
         }
@@ -308,28 +308,27 @@ final class FSAlbumView: UIView, UICollectionViewDataSource, UICollectionViewDel
         dispatch_async(dispatch_get_main_queue()) {
             
             let collectionChanges = changeInstance.changeDetailsForFetchResult(self.images)
-            if collectionChanges != nil {
-                
-                self.images = collectionChanges!.fetchResultAfterChanges
+            if let collectionChanges = collectionChanges {
+                self.images = collectionChanges.fetchResultAfterChanges
                 
                 let collectionView = self.collectionView!
                 
-                if !collectionChanges!.hasIncrementalChanges || collectionChanges!.hasMoves {
+                if !collectionChanges.hasIncrementalChanges || collectionChanges.hasMoves {
                     
                     collectionView.reloadData()
                     
                 } else {
                     
                     collectionView.performBatchUpdates({
-                        let removedIndexes = collectionChanges!.removedIndexes
+                        let removedIndexes = collectionChanges.removedIndexes
                         if (removedIndexes?.count ?? 0) != 0 {
                             collectionView.deleteItemsAtIndexPaths(removedIndexes!.aapl_indexPathsFromIndexesWithSection(0))
                         }
-                        let insertedIndexes = collectionChanges!.insertedIndexes
+                        let insertedIndexes = collectionChanges.insertedIndexes
                         if (insertedIndexes?.count ?? 0) != 0 {
                             collectionView.insertItemsAtIndexPaths(insertedIndexes!.aapl_indexPathsFromIndexesWithSection(0))
                         }
-                        let changedIndexes = collectionChanges!.changedIndexes
+                        let changedIndexes = collectionChanges.changedIndexes
                         if (changedIndexes?.count ?? 0) != 0 {
                             collectionView.reloadItemsAtIndexPaths(changedIndexes!.aapl_indexPathsFromIndexesWithSection(0))
                         }
@@ -403,8 +402,7 @@ private extension FSAlbumView {
             switch status {
             case .Authorized:
                 self.imageManager = PHCachingImageManager()
-                if self.images != nil && self.images.count > 0 {
-                    
+                if let _ = self.images where self.images.count > 0 {
                     self.changeImage(self.images[0] as! PHAsset)
                 }
                 

--- a/Sources/FSAlbumView.swift
+++ b/Sources/FSAlbumView.swift
@@ -24,7 +24,18 @@ final class FSAlbumView: UIView, UICollectionViewDataSource, UICollectionViewDel
     @IBOutlet weak var imageCropViewConstraintTop: NSLayoutConstraint!
     
     weak var delegate: FSAlbumViewDelegate? = nil
-    
+
+    override var backgroundColor: UIColor? {
+        didSet {
+            if collectionView != nil {
+                collectionView.backgroundColor = backgroundColor
+            }
+            if imageCropView != nil {
+                imageCropView.backgroundColor = backgroundColor
+            }
+        }
+    }
+
     var images: PHFetchResult!
     var imageManager: PHCachingImageManager?
     var previousPreheatRect: CGRect = CGRectZero
@@ -47,21 +58,14 @@ final class FSAlbumView: UIView, UICollectionViewDataSource, UICollectionViewDel
     var dragStartPos: CGPoint = CGPointZero
     let dragDiff: CGFloat     = 20.0
     
-    static func instance() -> FSAlbumView {
-        
-        return UINib(nibName: "FSAlbumView", bundle: NSBundle(forClass: self.classForCoder())).instantiateWithOwner(self, options: nil)[0] as! FSAlbumView
-    }
-    
     func initialize() {
-        
         if images != nil {
-            
             return
         }
 		
 		self.hidden = false
         
-        let panGesture      = UIPanGestureRecognizer(target: self, action: #selector(FSAlbumView.panned(_:)))
+        let panGesture = UIPanGestureRecognizer(target: self, action: #selector(FSAlbumView.panned(_:)))
         panGesture.delegate = self
         self.addGestureRecognizer(panGesture)
         
@@ -75,7 +79,7 @@ final class FSAlbumView: UIView, UICollectionViewDataSource, UICollectionViewDel
         imageCropViewContainer.layer.shadowOffset  = CGSizeZero
         
         collectionView.registerNib(UINib(nibName: "FSAlbumViewCell", bundle: NSBundle(forClass: self.classForCoder)), forCellWithReuseIdentifier: "FSAlbumViewCell")
-		collectionView.backgroundColor = fusumaBackgroundColor
+		collectionView.backgroundColor = self.backgroundColor
 		
         // Never load photos Unless the user allows to access to photo album
         checkPhotoAuth()

--- a/Sources/FSAlbumView.xib
+++ b/Sources/FSAlbumView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -28,7 +28,7 @@
                                 <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                             </collectionViewFlowLayout>
                             <connections>
-                                <outlet property="dataSource" destination="iN0-l3-epB" id="VtH-0G-lbm"/>
+                                <outlet property="dataSource" destination="iN0-l3-epB" id="9GB-Ib-QSS"/>
                                 <outlet property="delegate" destination="iN0-l3-epB" id="088-Hw-yCy"/>
                             </connections>
                         </collectionView>

--- a/Sources/FSAlbumViewCell.swift
+++ b/Sources/FSAlbumViewCell.swift
@@ -12,7 +12,9 @@ import Photos
 final class FSAlbumViewCell: UICollectionViewCell {
     
     @IBOutlet weak var imageView: UIImageView!
-    
+
+    internal var baseTintColor : UIColor = FSDefaults.baseTintColor
+
     var image: UIImage? {
         
         didSet {
@@ -28,7 +30,7 @@ final class FSAlbumViewCell: UICollectionViewCell {
     
     override var selected : Bool {
         didSet {
-            self.layer.borderColor = selected ? fusumaTintColor.CGColor : UIColor.clearColor().CGColor
+            self.layer.borderColor = selected ? baseTintColor.CGColor : UIColor.clearColor().CGColor
             self.layer.borderWidth = selected ? 2 : 0
         }
     }

--- a/Sources/FSCameraView.swift
+++ b/Sources/FSCameraView.swift
@@ -35,7 +35,8 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
     internal var flipImage: UIImage?
     internal var shotImage: UIImage?
     internal var baseTintColor: UIColor = FSDefaults.baseTintColor
-    internal var cropImage: Bool = true
+    internal var cropImage: Bool = FSDefaults.cropImage
+    internal var tintIcons: Bool = FSDefaults.tintIcons
 
     override func didMoveToSuperview() {
         let bundle = NSBundle(forClass: self.classForCoder)
@@ -45,7 +46,7 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
         flipImage = flipImage ?? UIImage(named: "ic_loop", inBundle: bundle, compatibleWithTraitCollection: nil)
         shotImage = shotImage ?? UIImage(named: "ic_radio_button_checked", inBundle: bundle, compatibleWithTraitCollection: nil)
 
-        if fusumaTintIcons {
+        if tintIcons {
             flashButton.tintColor = baseTintColor
             flipButton.tintColor  = baseTintColor
             shotButton.tintColor  = baseTintColor

--- a/Sources/FSCameraView.swift
+++ b/Sources/FSCameraView.swift
@@ -59,14 +59,13 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
             flipButton.setImage(flipImage, forState: .Normal)
             shotButton.setImage(shotImage, forState: .Normal)
         }
-
     }
 
     func initialize() {
         if session != nil {
             return
         }
-        
+
         self.hidden = false
         
         // AVCapture
@@ -86,6 +85,7 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
             if let session = session {
                 videoInput = try AVCaptureDeviceInput(device: device)
 
+                session.beginConfiguration()
                 session.addInput(videoInput)
                 
                 imageOutput = AVCaptureStillImageOutput()
@@ -99,6 +99,8 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
                 self.previewViewContainer.layer.addSublayer(videoLayer)
                 
                 session.sessionPreset = AVCaptureSessionPresetPhoto
+
+                session.commitConfiguration()
 
                 session.startRunning()
             }
@@ -114,8 +116,8 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
         }
 
         flashConfiguration()
-        
-        self.startCamera()
+
+        startCamera()
         
         NSNotificationCenter.defaultCenter().addObserver(self, selector: #selector(FSCameraView.willEnterForegroundNotification(_:)), name: UIApplicationWillEnterForegroundNotification, object: nil)
     }
@@ -135,12 +137,11 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
     }
     
     deinit {
-        
         NSNotificationCenter.defaultCenter().removeObserver(self)
     }
     
     func startCamera() {
-        
+
         let status = AVCaptureDevice.authorizationStatusForMediaType(AVMediaTypeVideo)
         
         if status == AVAuthorizationStatus.Authorized {

--- a/Sources/FSCameraView.xib
+++ b/Sources/FSCameraView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>

--- a/Sources/FSConstants.swift
+++ b/Sources/FSConstants.swift
@@ -8,6 +8,19 @@
 
 import UIKit
 
+internal struct FSDefaults {
+    static var baseTintColor = UIColor.hex("#FFFFFF", alpha: 1.0)
+    static var tintColor = UIColor.hex("#009688", alpha: 1.0)
+    static var backgroundColor = UIColor.hex("#212121", alpha: 1.0)
+
+    static var cropImage = true
+    static var tintIcons = true
+
+    static var cameraRollTitle = "CAMERA ROLL"
+    static var cameraTitle = "PHOTO"
+    static var videoTitle = "VIDEO"
+}
+
 // Extension
 internal extension UIColor {
     
@@ -38,4 +51,39 @@ extension UIView {
         self.layer.addSublayer(border)
     }
 
+}
+
+public extension UIView {
+    public class func fromNib(nibNameOrNil: String? = nil) -> Self {
+        return fromNib(nibNameOrNil, type: self)
+    }
+
+    public class func fromNib<T : UIView>(nibNameOrNil: String? = nil, type: T.Type) -> T {
+        let v: T? = fromNib(nibNameOrNil, type: T.self)
+        return v!
+    }
+
+    public class func fromNib<T : UIView>(nibNameOrNil: String? = nil, type: T.Type) -> T? {
+        var view: T?
+        let name = nibNameOrNil ?? nibName
+        let nibViews = NSBundle(forClass: self).loadNibNamed(name, owner: self, options: nil)
+        for v in nibViews {
+            if let tog = v as? T {
+                view = tog
+            }
+        }
+        return view
+    }
+
+    public class var nibName: String {
+        let name = "\(self)".componentsSeparatedByString(".").first ?? ""
+        return name
+    }
+    public class var nib: UINib? {
+        if let _ = NSBundle(forClass: self).pathForResource(nibName, ofType: "nib") {
+            return UINib(nibName: nibName, bundle: nil)
+        } else {
+            return nil
+        }
+    }
 }

--- a/Sources/FSImageCropView.swift
+++ b/Sources/FSImageCropView.swift
@@ -13,9 +13,11 @@ final class FSImageCropView: UIScrollView, UIScrollViewDelegate {
     var imageView = UIImageView()
     
     var imageSize: CGSize?
+
+    var cropImage = FSDefaults.cropImage
     
     var image: UIImage! = nil {
-        
+
         didSet {
             
             if image != nil {
@@ -31,7 +33,7 @@ final class FSImageCropView: UIScrollView, UIScrollViewDelegate {
                 return
             }
             
-            if !fusumaCropImage {
+            if !cropImage {
                 // Disable scroll view and set image to fit in view
                 imageView.frame = self.frame
                 imageView.contentMode = .ScaleAspectFit
@@ -121,7 +123,6 @@ final class FSImageCropView: UIScrollView, UIScrollViewDelegate {
         
         super.init(coder: aDecoder)!
         
-        self.backgroundColor = fusumaBackgroundColor
         self.frame.size      = CGSizeZero
         self.clipsToBounds   = true
         self.imageView.alpha = 0.0

--- a/Sources/FSVideoCameraView.swift
+++ b/Sources/FSVideoCameraView.swift
@@ -28,27 +28,20 @@ final class FSVideoCameraView: UIView {
     var videoOutput: AVCaptureMovieFileOutput?
     var focusView: UIView?
     
-    var flashOffImage: UIImage?
-    var flashOnImage: UIImage?
-    var videoStartImage: UIImage?
-    var videoStopImage: UIImage?
-
+    internal var flashOffImage: UIImage?
+    internal var flashOnImage: UIImage?
+    internal var flipImage: UIImage?
+    internal var videoStartImage: UIImage?
+    internal var videoStopImage: UIImage?
+    internal var baseTintColor: UIColor?
     
     private var isRecording = false
-    
-    static func instance() -> FSVideoCameraView {
-        
-        return UINib(nibName: "FSVideoCameraView", bundle: NSBundle(forClass: self.classForCoder())).instantiateWithOwner(self, options: nil)[0] as! FSVideoCameraView
-    }
     
     func initialize() {
         
         if session != nil {
-            
             return
         }
-        
-        self.backgroundColor = fusumaBackgroundColor
         
         self.hidden = false
         
@@ -56,17 +49,13 @@ final class FSVideoCameraView: UIView {
         session = AVCaptureSession()
         
         for device in AVCaptureDevice.devices() {
-            
             if let device = device as? AVCaptureDevice where device.position == AVCaptureDevicePosition.Back {
-                
                 self.device = device
             }
         }
         
         do {
-            
             if let session = session {
-                
                 videoInput = try AVCaptureDeviceInput(device: device)
                 
                 session.addInput(videoInput)
@@ -78,7 +67,7 @@ final class FSVideoCameraView: UIView {
                 let maxDuration = CMTimeMakeWithSeconds(totalSeconds, timeScale)
                 
                 videoOutput?.maxRecordedDuration = maxDuration
-                videoOutput?.minFreeDiskSpaceLimit = 1024 * 1024 //SET MIN FREE SPACE IN BYTES FOR RECORDING TO CONTINUE ON A VOLUME
+                videoOutput?.minFreeDiskSpaceLimit = 1024 * 1024 // SET MIN FREE SPACE IN BYTES FOR RECORDING TO CONTINUE ON A VOLUME
                 
                 if session.canAddOutput(videoOutput) {
                     session.addOutput(videoOutput)
@@ -106,17 +95,17 @@ final class FSVideoCameraView: UIView {
         
         let bundle = NSBundle(forClass: self.classForCoder)
         
-        flashOnImage = fusumaFlashOnImage != nil ? fusumaFlashOnImage : UIImage(named: "ic_flash_on", inBundle: bundle, compatibleWithTraitCollection: nil)
-        flashOffImage = fusumaFlashOffImage != nil ? fusumaFlashOffImage : UIImage(named: "ic_flash_off", inBundle: bundle, compatibleWithTraitCollection: nil)
-        let flipImage = fusumaFlipImage != nil ? fusumaFlipImage : UIImage(named: "ic_loop", inBundle: bundle, compatibleWithTraitCollection: nil)
-        videoStartImage = fusumaVideoStartImage != nil ? fusumaVideoStartImage : UIImage(named: "video_button", inBundle: bundle, compatibleWithTraitCollection: nil)
-        videoStopImage = fusumaVideoStopImage != nil ? fusumaVideoStopImage : UIImage(named: "video_button_rec", inBundle: bundle, compatibleWithTraitCollection: nil)
+        flashOnImage = flashOnImage ?? UIImage(named: "ic_flash_on", inBundle: bundle, compatibleWithTraitCollection: nil)
+        flashOffImage = flashOffImage ?? UIImage(named: "ic_flash_off", inBundle: bundle, compatibleWithTraitCollection: nil)
+        flipImage = flipImage ?? UIImage(named: "ic_loop", inBundle: bundle, compatibleWithTraitCollection: nil)
+        videoStartImage = videoStartImage ?? UIImage(named: "video_button", inBundle: bundle, compatibleWithTraitCollection: nil)
+        videoStopImage = videoStopImage ?? UIImage(named: "video_button_rec", inBundle: bundle, compatibleWithTraitCollection: nil)
 
         
         if(fusumaTintIcons) {
-            flashButton.tintColor = fusumaBaseTintColor
-            flipButton.tintColor  = fusumaBaseTintColor
-            shotButton.tintColor  = fusumaBaseTintColor
+            flashButton.tintColor = baseTintColor
+            flipButton.tintColor  = baseTintColor
+            shotButton.tintColor  = baseTintColor
             
             flashButton.setImage(flashOffImage?.imageWithRenderingMode(.AlwaysTemplate), forState: .Normal)
             flipButton.setImage(flipImage?.imageWithRenderingMode(.AlwaysTemplate), forState: .Normal)

--- a/Sources/FSVideoCameraView.swift
+++ b/Sources/FSVideoCameraView.swift
@@ -58,21 +58,24 @@ final class FSVideoCameraView: UIView {
         do {
             if let session = session {
                 videoInput = try AVCaptureDeviceInput(device: device)
-                
-                session.addInput(videoInput)
-                
+
                 videoOutput = AVCaptureMovieFileOutput()
                 let totalSeconds = 60.0 //Total Seconds of capture time
                 let timeScale: Int32 = 30 //FPS
-                
+
                 let maxDuration = CMTimeMakeWithSeconds(totalSeconds, timeScale)
-                
+
                 videoOutput?.maxRecordedDuration = maxDuration
                 videoOutput?.minFreeDiskSpaceLimit = 1024 * 1024 // SET MIN FREE SPACE IN BYTES FOR RECORDING TO CONTINUE ON A VOLUME
+
+                session.beginConfiguration()
+                session.addInput(videoInput)
                 
                 if session.canAddOutput(videoOutput) {
                     session.addOutput(videoOutput)
                 }
+
+                session.commitConfiguration()
                 
                 let videoLayer = AVCaptureVideoPreviewLayer(session: session)
                 videoLayer.frame = self.previewViewContainer.bounds
@@ -116,10 +119,10 @@ final class FSVideoCameraView: UIView {
             flipButton.setImage(flipImage, forState: .Normal)
             shotButton.setImage(videoStartImage, forState: .Normal)
         }
+
+        startCamera()
         
         flashConfiguration()
-        
-        self.startCamera()
     }
     
     deinit {
@@ -128,7 +131,7 @@ final class FSVideoCameraView: UIView {
     }
     
     func startCamera() {
-        
+
         let status = AVCaptureDevice.authorizationStatusForMediaType(AVMediaTypeVideo)
         
         if status == AVAuthorizationStatus.Authorized {

--- a/Sources/FSVideoCameraView.swift
+++ b/Sources/FSVideoCameraView.swift
@@ -34,6 +34,7 @@ final class FSVideoCameraView: UIView {
     internal var videoStartImage: UIImage?
     internal var videoStopImage: UIImage?
     internal var baseTintColor: UIColor?
+    internal var tintIcons = FSDefaults.tintIcons
     
     private var isRecording = false
     
@@ -102,7 +103,7 @@ final class FSVideoCameraView: UIView {
         videoStopImage = videoStopImage ?? UIImage(named: "video_button_rec", inBundle: bundle, compatibleWithTraitCollection: nil)
 
         
-        if(fusumaTintIcons) {
+        if tintIcons {
             flashButton.tintColor = baseTintColor
             flipButton.tintColor  = baseTintColor
             shotButton.tintColor  = baseTintColor

--- a/Sources/FSVideoCameraView.xib
+++ b/Sources/FSVideoCameraView.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -269,15 +269,10 @@ public final class FusumaViewController: UIViewController {
             button.addConstraint(noHeightConstraint)
         }
 
-        self.view.layoutIfNeeded()
+        cameraView.croppedAspectRatioConstraint.active = cropImage
+        cameraView.fullAspectRatioConstraint.active = !cropImage
 
-        if cropImage {
-            cameraView.fullAspectRatioConstraint.active = false
-            cameraView.croppedAspectRatioConstraint.active = true
-        } else {
-            cameraView.fullAspectRatioConstraint.active = true
-            cameraView.croppedAspectRatioConstraint.active = false
-        }
+        self.view.layoutIfNeeded()
 
         // change to the first mode
         changeMode(availableModes.first!)
@@ -286,17 +281,25 @@ public final class FusumaViewController: UIViewController {
     override public func viewDidAppear(animated: Bool) {
         super.viewDidAppear(animated)
 
-        albumView.frame  = CGRect(origin: CGPointZero, size: photoLibraryViewerContainer.frame.size)
-        albumView.layoutIfNeeded()
-        albumView.initialize()
-
-        cameraView.frame = CGRect(origin: CGPointZero, size: cameraShotContainer.frame.size)
-        cameraView.layoutIfNeeded()
-        cameraView.initialize()
-
-        videoView.frame = CGRect(origin: CGPointZero, size: videoShotContainer.frame.size)
-        videoView.layoutIfNeeded()
-        videoView.initialize()
+        // only initialize the view if we're using that mode
+        availableModes.forEach { mode in
+            switch mode {
+            case .Camera:
+                cameraView.frame = CGRect(origin: CGPointZero, size: cameraShotContainer.frame.size)
+                cameraView.layoutIfNeeded()
+                cameraView.initialize()
+            case .Video:
+                videoView.frame = CGRect(origin: CGPointZero, size: videoShotContainer.frame.size)
+                videoView.layoutIfNeeded()
+                videoView.initialize()
+            case .Library:
+                albumView.frame  = CGRect(origin: CGPointZero, size: photoLibraryViewerContainer.frame.size)
+                albumView.layoutIfNeeded()
+                albumView.initialize()
+            default:
+                break
+            }
+        }
     }
 
     public override func viewWillDisappear(animated: Bool) {
@@ -420,7 +423,7 @@ private extension FusumaViewController {
         }
 
         // operate this switch before changing mode to stop cameras
-        switch mode {
+        switch self.mode {
         case .Camera:
             self.cameraView.stopCamera()
         case .Video:

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -12,7 +12,6 @@ import Photos
 @objc public protocol FusumaDelegate: class {
     
     func fusumaImageSelected(image: UIImage)
-    optional func fusumaDismissedWithImage(image: UIImage)
     func fusumaVideoCompleted(withFileURL fileURL: NSURL)
     func fusumaCameraRollUnauthorized()
     
@@ -250,10 +249,7 @@ public final class FusumaViewController: UIViewController {
     }
     
     @IBAction func closeButtonPressed(sender: UIButton) {
-        self.dismissViewControllerAnimated(true, completion: {
-            
-            self.delegate?.fusumaClosed?()
-        })
+        self.delegate?.fusumaClosed?()
     }
     
     @IBAction func libraryButtonPressed(sender: UIButton) {
@@ -303,20 +299,12 @@ public final class FusumaViewController: UIViewController {
                     
                     dispatch_async(dispatch_get_main_queue(), {
                         self.delegate?.fusumaImageSelected(result!)
-                        
-                        self.dismissViewControllerAnimated(true, completion: {
-                            self.delegate?.fusumaDismissedWithImage?(result!)
-                        })
                     })
                 }
             })
         } else {
             print("no image crop ")
             delegate?.fusumaImageSelected(view.image)
-            
-            self.dismissViewControllerAnimated(true, completion: {
-                self.delegate?.fusumaDismissedWithImage?(view.image)
-            })
         }
     }
     
@@ -326,12 +314,7 @@ extension FusumaViewController: FSAlbumViewDelegate, FSCameraViewDelegate, FSVid
     
     // MARK: FSCameraViewDelegate
     func cameraShotFinished(image: UIImage) {
-        
         delegate?.fusumaImageSelected(image)
-        self.dismissViewControllerAnimated(true, completion: {
-            
-            self.delegate?.fusumaDismissedWithImage?(image)
-        })
     }
     
     // MARK: FSAlbumViewDelegate
@@ -341,7 +324,6 @@ extension FusumaViewController: FSAlbumViewDelegate, FSCameraViewDelegate, FSVid
     
     func videoFinished(withFileURL fileURL: NSURL) {
         delegate?.fusumaVideoCompleted(withFileURL: fileURL)
-        self.dismissViewControllerAnimated(true, completion: nil)
     }
     
 }

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -180,7 +180,7 @@ public final class FusumaViewController: UIViewController {
         cameraShotContainer.addSubview(cameraView)
         videoShotContainer.addSubview(videoView)
         
-		titleLabel.textColor = fusumaBaseTintColor
+        titleLabel.textColor = fusumaBaseTintColor
 		
 //        if modeOrder != .LibraryFirst {
 //            libraryFirstConstraints.forEach { $0.priority = 250 }

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -10,8 +10,7 @@ import UIKit
 import Photos
 
 @objc public protocol FusumaDelegate: class {
-    
-    func fusuma(fusuma: FusumaViewController, imageSelected image: UIImage)
+    func fusuma(fusuma: FusumaViewController, imageSelected image: UIImage, viaMode mode: Int)
     func fusuma(fusuma: FusumaViewController, videoCompletedWithFileURL fileURL: NSURL)
     func fusumaCameraRollUnauthorized(fusuma: FusumaViewController)
 
@@ -48,13 +47,13 @@ public enum FusumaModeOrder {
     case LibraryFirst
 }
 
+public enum FusumaMode : Int {
+  case Camera
+  case Library
+  case Video
+}
+
 public final class FusumaViewController: UIViewController {
-    
-    enum Mode {
-        case Camera
-        case Library
-        case Video
-    }
 
     // Mirror module properties to instance variables
     public var hasVideo = false
@@ -84,7 +83,7 @@ public final class FusumaViewController: UIViewController {
     public var tintIcons = fusumaTintIcons
     // End mirroring properties
 
-    var mode: Mode = Mode.Camera
+    var mode: FusumaMode = .Camera
     public var modeOrder: FusumaModeOrder = .CameraFirst
     var willFilter = true
 
@@ -200,7 +199,7 @@ public final class FusumaViewController: UIViewController {
         libraryButton.clipsToBounds = true
         videoButton.clipsToBounds = true
 
-        changeMode(Mode.Library)
+        changeMode(.Library)
         
         photoLibraryViewerContainer.addSubview(albumView)
         cameraShotContainer.addSubview(cameraView)
@@ -272,15 +271,15 @@ public final class FusumaViewController: UIViewController {
     }
     
     @IBAction func libraryButtonPressed(sender: UIButton) {
-        changeMode(Mode.Library)
+        changeMode(.Library)
     }
     
     @IBAction func photoButtonPressed(sender: UIButton) {
-        changeMode(Mode.Camera)
+        changeMode(.Camera)
     }
     
     @IBAction func videoButtonPressed(sender: UIButton) {
-        changeMode(Mode.Video)
+        changeMode(.Video)
     }
     
     @IBAction func doneButtonPressed(sender: UIButton) {
@@ -314,12 +313,12 @@ public final class FusumaViewController: UIViewController {
                     result, info in
                     
                     dispatch_async(dispatch_get_main_queue(), {
-                        self.delegate?.fusuma(self, imageSelected: result!)
+                        self.delegate?.fusuma(self, imageSelected: result!, viaMode: self.mode.rawValue)
                     })
                 }
             })
         } else {
-            delegate?.fusuma(self, imageSelected: view.image)
+            delegate?.fusuma(self, imageSelected: view.image, viaMode: self.mode.rawValue)
         }
     }
     
@@ -329,7 +328,7 @@ extension FusumaViewController: FSAlbumViewDelegate, FSCameraViewDelegate, FSVid
     
     // MARK: FSCameraViewDelegate
     func cameraShotFinished(image: UIImage) {
-        delegate?.fusuma(self, imageSelected: image)
+        delegate?.fusuma(self, imageSelected: image, viaMode: self.mode.rawValue)
     }
     
     // MARK: FSAlbumViewDelegate
@@ -363,7 +362,7 @@ private extension FusumaViewController {
         self.cameraView.stopCamera()
     }
     
-    func changeMode(mode: Mode) {
+    func changeMode(mode: FusumaMode) {
 
         if self.mode == mode {
             return

--- a/Sources/FusumaViewController.xib
+++ b/Sources/FusumaViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15G1004" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -101,19 +101,6 @@
                         <action selector="libraryButtonPressed:" destination="-1" eventType="touchUpInside" id="4H9-TH-qO3"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8ew-Zi-63G">
-                    <rect key="frame" x="400" y="555" width="200" height="45"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="45" id="vif-4h-eUh"/>
-                    </constraints>
-                    <inset key="imageEdgeInsets" minX="2" minY="3" maxX="2" maxY="2"/>
-                    <state key="normal" image="ic_videocam"/>
-                    <state key="selected" image="ic_photo_camera"/>
-                    <state key="highlighted" image="ic_photo_camera"/>
-                    <connections>
-                        <action selector="videoButtonPressed:" destination="-1" eventType="touchUpInside" id="jZa-kI-xDJ"/>
-                    </connections>
-                </button>
                 <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sCN-QB-mCu">
                     <rect key="frame" x="200" y="555" width="200" height="45"/>
                     <constraints>
@@ -125,6 +112,19 @@
                     <state key="highlighted" image="ic_photo_camera"/>
                     <connections>
                         <action selector="photoButtonPressed:" destination="-1" eventType="touchUpInside" id="798-LR-edY"/>
+                    </connections>
+                </button>
+                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8ew-Zi-63G">
+                    <rect key="frame" x="400" y="555" width="200" height="45"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="45" id="vif-4h-eUh"/>
+                    </constraints>
+                    <inset key="imageEdgeInsets" minX="2" minY="3" maxX="2" maxY="2"/>
+                    <state key="normal" image="ic_videocam"/>
+                    <state key="selected" image="ic_photo_camera"/>
+                    <state key="highlighted" image="ic_photo_camera"/>
+                    <connections>
+                        <action selector="videoButtonPressed:" destination="-1" eventType="touchUpInside" id="jZa-kI-xDJ"/>
                     </connections>
                 </button>
             </subviews>

--- a/Sources/FusumaViewController.xib
+++ b/Sources/FusumaViewController.xib
@@ -88,10 +88,10 @@
                         <constraint firstItem="Dx0-Tt-oZs" firstAttribute="top" secondItem="8ba-kc-jlJ" secondAttribute="top" constant="8" id="phx-7N-5Ks"/>
                     </constraints>
                 </view>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cph-QM-jcJ">
+                <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="cph-QM-jcJ">
                     <rect key="frame" x="0.0" y="555" width="200" height="45"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="45" id="ef6-hG-yx4"/>
+                        <constraint firstAttribute="height" priority="999" constant="45" id="ef6-hG-yx4"/>
                     </constraints>
                     <inset key="contentEdgeInsets" minX="2" minY="2" maxX="2" maxY="2"/>
                     <state key="normal" image="ic_insert_photo"/>
@@ -101,10 +101,10 @@
                         <action selector="libraryButtonPressed:" destination="-1" eventType="touchUpInside" id="4H9-TH-qO3"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sCN-QB-mCu">
+                <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="sCN-QB-mCu">
                     <rect key="frame" x="200" y="555" width="200" height="45"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="45" id="7VV-4q-BRr"/>
+                        <constraint firstAttribute="height" priority="999" constant="45" id="7VV-4q-BRr"/>
                     </constraints>
                     <inset key="imageEdgeInsets" minX="2" minY="3" maxX="2" maxY="2"/>
                     <state key="normal" image="ic_photo_camera"/>
@@ -114,10 +114,10 @@
                         <action selector="photoButtonPressed:" destination="-1" eventType="touchUpInside" id="798-LR-edY"/>
                     </connections>
                 </button>
-                <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8ew-Zi-63G">
+                <button opaque="NO" contentMode="scaleToFill" ambiguous="YES" misplaced="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="8ew-Zi-63G">
                     <rect key="frame" x="400" y="555" width="200" height="45"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="45" id="vif-4h-eUh"/>
+                        <constraint firstAttribute="height" priority="999" constant="45" id="vif-4h-eUh"/>
                     </constraints>
                     <inset key="imageEdgeInsets" minX="2" minY="3" maxX="2" maxY="2"/>
                     <state key="normal" image="ic_videocam"/>
@@ -132,23 +132,18 @@
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="8ba-kc-jlJ" secondAttribute="trailing" id="00c-gY-uy6"/>
                 <constraint firstItem="1Pk-29-mUG" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="0rm-S1-9o9"/>
-                <constraint firstItem="sCN-QB-mCu" firstAttribute="leading" secondItem="cph-QM-jcJ" secondAttribute="trailing" id="8Df-A3-2bv"/>
+                <constraint firstItem="cph-QM-jcJ" firstAttribute="top" secondItem="1Pk-29-mUG" secondAttribute="bottom" id="7M7-rq-4Nm"/>
                 <constraint firstItem="8ba-kc-jlJ" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="ADX-qy-sfu"/>
                 <constraint firstAttribute="bottom" secondItem="sCN-QB-mCu" secondAttribute="bottom" id="Eol-81-9UT"/>
-                <constraint firstItem="sCN-QB-mCu" firstAttribute="top" secondItem="cph-QM-jcJ" secondAttribute="top" id="K1G-U0-Vgk"/>
+                <constraint firstAttribute="bottom" secondItem="8ew-Zi-63G" secondAttribute="bottom" id="J6u-kh-FG1"/>
                 <constraint firstItem="CFH-FU-LPW" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="QcH-4o-bGU"/>
-                <constraint firstItem="sCN-QB-mCu" firstAttribute="top" secondItem="8ew-Zi-63G" secondAttribute="top" id="TRC-fO-jAk"/>
                 <constraint firstItem="8ba-kc-jlJ" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="Tq6-c6-93y"/>
-                <constraint firstItem="sCN-QB-mCu" firstAttribute="width" secondItem="cph-QM-jcJ" secondAttribute="width" id="ZJg-S4-hJ4"/>
                 <constraint firstItem="RIt-Tt-mDz" firstAttribute="leading" secondItem="1Pk-29-mUG" secondAttribute="leading" id="Zh6-JC-yZB"/>
-                <constraint firstAttribute="trailing" secondItem="8ew-Zi-63G" secondAttribute="trailing" id="aK8-hD-s6X"/>
                 <constraint firstAttribute="trailing" secondItem="1Pk-29-mUG" secondAttribute="trailing" id="b0C-4x-heo"/>
-                <constraint firstItem="sCN-QB-mCu" firstAttribute="width" secondItem="8ew-Zi-63G" secondAttribute="width" id="ctQ-Ka-mGj"/>
+                <constraint firstItem="8ew-Zi-63G" firstAttribute="top" secondItem="1Pk-29-mUG" secondAttribute="bottom" id="baD-y4-YTL"/>
                 <constraint firstItem="CFH-FU-LPW" firstAttribute="trailing" secondItem="1Pk-29-mUG" secondAttribute="trailing" id="dTI-0B-myd"/>
                 <constraint firstItem="RIt-Tt-mDz" firstAttribute="top" secondItem="i5M-Pr-FkT" secondAttribute="top" id="gTV-NE-IMv"/>
                 <constraint firstItem="1Pk-29-mUG" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="gbM-f6-jpP"/>
-                <constraint firstItem="8ew-Zi-63G" firstAttribute="leading" secondItem="sCN-QB-mCu" secondAttribute="trailing" id="lX7-Hu-YUi"/>
-                <constraint firstItem="cph-QM-jcJ" firstAttribute="leading" secondItem="i5M-Pr-FkT" secondAttribute="leading" id="r6i-pH-gQl"/>
                 <constraint firstItem="RIt-Tt-mDz" firstAttribute="trailing" secondItem="1Pk-29-mUG" secondAttribute="trailing" id="u9n-zf-deV"/>
                 <constraint firstItem="CFH-FU-LPW" firstAttribute="leading" secondItem="1Pk-29-mUG" secondAttribute="leading" id="xYp-HY-RNh"/>
                 <constraint firstItem="sCN-QB-mCu" firstAttribute="top" secondItem="1Pk-29-mUG" secondAttribute="bottom" id="yNf-NX-89v"/>

--- a/Sources/FusumaViewController.xib
+++ b/Sources/FusumaViewController.xib
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15G31" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
@@ -61,9 +61,7 @@
                                 <constraint firstAttribute="width" constant="40" id="NE8-9R-uXl"/>
                             </constraints>
                             <inset key="contentEdgeInsets" minX="8" minY="8" maxX="8" maxY="8"/>
-                            <state key="normal" image="ic_check"/>
                             <state key="selected" image="ic_check"/>
-                            <state key="highlighted" image="ic_check"/>
                             <connections>
                                 <action selector="doneButtonPressed:" destination="-1" eventType="touchUpInside" id="Ym5-Qc-exH"/>
                             </connections>


### PR DESCRIPTION
Hi, thanks for this wonderful library! I have used it in lots of my projects. In my latest project I only wanted to show the camera, without the library or video sections, so I added that feature.

I also moved the configuration from module-level variables to instance variables on `FusumaViewController` so that it's easy to have separate styles for different instances of `FusumaViewController`.

I changed the delegate methods to pass the `FusumaViewController` instance to the delegate, and also the `FusumaMode` that was used to acquire the image (`.Library` or `.Camera`)

I added `availableModes` that allows the user to decide which tabs to show (and their order). You can now do `fusuma.availableModes = [.Camera, .Library]` and it will show the camera (selected first) and have a tab for the library on the right. You can also pass a single value (`fusuma.availableModes = [.Camera]`) and it will only show that tab, with no buttons at the bottom.

I've also changed the `FusumaExample` project to import the `Fusuma` module instead of building the source files itself. This makes it a more realistic real-world example project.
