### PR TITLE
Ensure check box is visible after authorizing gallery

### DIFF
--- a/Example/FusumaExample/Info.plist
+++ b/Example/FusumaExample/Info.plist
@@ -34,6 +34,8 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>The app will allow you to choose images from your photo library.</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Sources/FSAlbumView.swift
+++ b/Sources/FSAlbumView.swift
@@ -12,6 +12,7 @@ import Photos
 @objc public protocol FSAlbumViewDelegate: class {
     
     func albumViewCameraRollUnauthorized()
+    func albumViewCameraRollAuthorized()
 }
 
 final class FSAlbumView: UIView, UICollectionViewDataSource, UICollectionViewDelegate, PHPhotoLibraryChangeObserver, UIGestureRecognizerDelegate {
@@ -402,6 +403,10 @@ private extension FSAlbumView {
                 if self.images != nil && self.images.count > 0 {
                     
                     self.changeImage(self.images[0])
+                }
+                
+                DispatchQueue.main.async {
+                    self.delegate?.albumViewCameraRollAuthorized()
                 }
                 
             case .restricted, .denied:

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -354,6 +354,12 @@ extension FusumaViewController: FSAlbumViewDelegate, FSCameraViewDelegate, FSVid
         })
     }
     
+    public func albumViewCameraRollAuthorized() {
+        // in the case that we're just coming back from granting photo gallery permissions
+        // ensure the done button is visible if it should be
+        self.updateDoneButtonVisibility()
+    }
+    
     // MARK: FSAlbumViewDelegate
     public func albumViewCameraRollUnauthorized() {
         delegate?.fusumaCameraRollUnauthorized()
@@ -397,24 +403,22 @@ private extension FusumaViewController {
         self.mode = mode
         
         dishighlightButtons()
+        updateDoneButtonVisibility()
         
         switch mode {
         case .library:
             titleLabel.text = NSLocalizedString(fusumaCameraRollTitle, comment: fusumaCameraRollTitle)
-            doneButton.isHidden = false
             
             highlightButton(libraryButton)
             self.view.bringSubview(toFront: photoLibraryViewerContainer)
         case .camera:
             titleLabel.text = NSLocalizedString(fusumaCameraTitle, comment: fusumaCameraTitle)
-            doneButton.isHidden = true
             
             highlightButton(cameraButton)
             self.view.bringSubview(toFront: cameraShotContainer)
             cameraView.startCamera()
         case .video:
             titleLabel.text = fusumaVideoTitle
-            doneButton.isHidden = true
             
             highlightButton(videoButton)
             self.view.bringSubview(toFront: videoShotContainer)
@@ -424,6 +428,21 @@ private extension FusumaViewController {
         self.view.bringSubview(toFront: menuView)
     }
     
+    
+    func updateDoneButtonVisibility() {
+        // don't show the done button without gallery permission
+        if !hasGalleryPermission {
+            self.doneButton.isHidden = true
+            return
+        }
+
+        switch self.mode {
+        case .library:
+            self.doneButton.isHidden = false
+        default:
+            self.doneButton.isHidden = true
+        }
+    }
     
     func dishighlightButtons() {
         cameraButton.tintColor  = fusumaBaseTintColor


### PR DESCRIPTION
Currently, the done button is hidden when gallery permissions do not exist. In cases where the host app has not yet asked for gallery permissions, this causes the check mark to be hidden throughout the entire first Fusuma session. Currently, the Fusuma window must be closed and relaunched for the done button to be visible again. This PR adds a `albumViewCameraRollAuthorized` delegate method similar to the existing `albumViewCameraRollUnauthorized` delegate method so that we can update the button visibility once permissions have been granted.