### PR TITLE
Fix #91 #97

### DIFF
--- a/Example/FusumaExample/Info.plist
+++ b/Example/FusumaExample/Info.plist
@@ -22,6 +22,10 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>The app will allow you to choose images from your photo library.</string>
+	<key>NSCameraUsageDescription</key>
+	<string>The app will allow you to capture images from your device camera.</string>
 	<key>UILaunchStoryboardName</key>
 	<string>LaunchScreen</string>
 	<key>UIMainStoryboardFile</key>
@@ -34,8 +38,6 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
-	<key>NSPhotoLibraryUsageDescription</key>
-	<string>The app will allow you to choose images from your photo library.</string>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>

--- a/Example/FusumaExample/ViewController.swift
+++ b/Example/FusumaExample/ViewController.swift
@@ -39,9 +39,16 @@ class ViewController: UIViewController, FusumaDelegate {
     }
     
     // MARK: FusumaDelegate Protocol
-    func fusumaImageSelected(_ image: UIImage) {
+    func fusumaImageSelected(_ image: UIImage, source: FusumaMode) {
+        switch source {
+        case .camera:
+            print("Image captured from Camera")
+        case .library:
+            print("Image selected from Camera Roll")
+        default:
+            print("Image selected")
+        }
         
-        print("Image selected")
         imageView.image = image
     }
     
@@ -50,9 +57,15 @@ class ViewController: UIViewController, FusumaDelegate {
         self.fileUrlLabel.text = "file output to: \(fileURL.absoluteString)"
     }
     
-    func fusumaDismissedWithImage(_ image: UIImage) {
-        
-        print("Called just after dismissed FusumaViewController")
+    func fusumaDismissedWithImage(_ image: UIImage, source: FusumaMode) {
+        switch source {
+        case .camera:
+            print("Called just after dismissed FusumaViewController using Camera")
+        case .library:
+            print("Called just after dismissed FusumaViewController using Camera Roll")
+        default:
+            print("Called just after dismissed FusumaViewController")
+        }
     }
     
     func fusumaCameraRollUnauthorized() {

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -29,14 +29,20 @@ fileprivate func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
 }
 
 
-@objc public protocol FusumaDelegate: class {
-    
-    func fusumaImageSelected(_ image: UIImage)
-    @objc optional func fusumaDismissedWithImage(_ image: UIImage)
+public protocol FusumaDelegate: class {
+    // MARK: Required
+    func fusumaImageSelected(_ image: UIImage, source: FusumaMode)
     func fusumaVideoCompleted(withFileURL fileURL: URL)
     func fusumaCameraRollUnauthorized()
-    
-    @objc optional func fusumaClosed()
+ 
+    // MARK: Optional
+    func fusumaDismissedWithImage(_ image: UIImage, source: FusumaMode)
+    func fusumaClosed()
+}
+
+extension FusumaDelegate {
+    func fusumaDismissedWithImage(_ image: UIImage, source: FusumaMode) {}
+    func fusumaClosed() {}
 }
 
 public var fusumaBaseTintColor   = UIColor.hex("#FFFFFF", alpha: 1.0)
@@ -70,18 +76,18 @@ public enum FusumaModeOrder {
     case libraryFirst
 }
 
+public enum FusumaMode {
+    case camera
+    case library
+    case video
+}
+
 //@objc public class FusumaViewController: UIViewController, FSCameraViewDelegate, FSAlbumViewDelegate {
 public final class FusumaViewController: UIViewController {
-    
-    enum Mode {
-        case camera
-        case library
-        case video
-    }
 
     public var hasVideo = false
 
-    var mode: Mode = .camera
+    var mode: FusumaMode = .camera
     public var modeOrder: FusumaModeOrder = .libraryFirst
     var willFilter = true
 
@@ -195,7 +201,7 @@ public final class FusumaViewController: UIViewController {
         libraryButton.clipsToBounds = true
         videoButton.clipsToBounds = true
 
-        changeMode(Mode.library)
+        changeMode(FusumaMode.library)
         
         photoLibraryViewerContainer.addSubview(albumView)
         cameraShotContainer.addSubview(cameraView)
@@ -274,23 +280,23 @@ public final class FusumaViewController: UIViewController {
     @IBAction func closeButtonPressed(_ sender: UIButton) {
         self.dismiss(animated: true, completion: {
             
-            self.delegate?.fusumaClosed?()
+            self.delegate?.fusumaClosed()
         })
     }
     
     @IBAction func libraryButtonPressed(_ sender: UIButton) {
         
-        changeMode(Mode.library)
+        changeMode(FusumaMode.library)
     }
     
     @IBAction func photoButtonPressed(_ sender: UIButton) {
     
-        changeMode(Mode.camera)
+        changeMode(FusumaMode.camera)
     }
     
     @IBAction func videoButtonPressed(_ sender: UIButton) {
         
-        changeMode(Mode.video)
+        changeMode(FusumaMode.video)
     }
     
     @IBAction func doneButtonPressed(_ sender: UIButton) {
@@ -324,20 +330,20 @@ public final class FusumaViewController: UIViewController {
                     result, info in
                     
                     DispatchQueue.main.async(execute: {
-                        self.delegate?.fusumaImageSelected(result!)
+                        self.delegate?.fusumaImageSelected(result!, source: self.mode)
                         
                         self.dismiss(animated: true, completion: {
-                            self.delegate?.fusumaDismissedWithImage?(result!)
+                            self.delegate?.fusumaDismissedWithImage(result!, source: self.mode)
                         })
                     })
                 }
             })
         } else {
             print("no image crop ")
-            delegate?.fusumaImageSelected((view?.image)!)
+            delegate?.fusumaImageSelected((view?.image)!, source: mode)
             
             self.dismiss(animated: true, completion: {
-                self.delegate?.fusumaDismissedWithImage?((view?.image)!)
+                self.delegate?.fusumaDismissedWithImage((view?.image)!, source: self.mode)
             })
         }
     }
@@ -349,10 +355,10 @@ extension FusumaViewController: FSAlbumViewDelegate, FSCameraViewDelegate, FSVid
     // MARK: FSCameraViewDelegate
     func cameraShotFinished(_ image: UIImage) {
         
-        delegate?.fusumaImageSelected(image)
+        delegate?.fusumaImageSelected(image, source: mode)
         self.dismiss(animated: true, completion: {
             
-            self.delegate?.fusumaDismissedWithImage?(image)
+            self.delegate?.fusumaDismissedWithImage(image, source: self.mode)
         })
     }
     
@@ -386,7 +392,7 @@ private extension FusumaViewController {
         self.cameraView.stopCamera()
     }
     
-    func changeMode(_ mode: Mode) {
+    func changeMode(_ mode: FusumaMode) {
 
         if self.mode == mode {
             return


### PR DESCRIPTION
- Add support for image `source` in delegate methods; to tell weather the image was selected from Camera Roll or captured from device's camera. This could be helpful in cases where you need to specify some actions to a specific source (e.g. saving images captured from camera to Camera Roll)
- Add missing camera permission privacy message to info.plist (this was causing a crash)