### PR TITLE
Custom crop ratio

### DIFF
--- a/Example/FusumaExample/ViewController.swift
+++ b/Example/FusumaExample/ViewController.swift
@@ -35,6 +35,8 @@ class ViewController: UIViewController, FusumaDelegate {
         //        fusumaCropImage = false
         
         fusuma.delegate = self
+        fusuma.cropHeightRatio = 0.6
+
         self.present(fusuma, animated: true, completion: nil)
     }
     

--- a/Sources/FSAlbumView.swift
+++ b/Sources/FSAlbumView.swift
@@ -10,7 +10,9 @@ import UIKit
 import Photos
 
 @objc public protocol FSAlbumViewDelegate: class {
-    
+    // Returns height ratio of crop image. e.g) 4:3 -> 7.5
+    func getCropHeightRatio() -> CGFloat
+
     func albumViewCameraRollUnauthorized()
     func albumViewCameraRollAuthorized()
 }
@@ -23,7 +25,7 @@ final class FSAlbumView: UIView, UICollectionViewDataSource, UICollectionViewDel
     
     @IBOutlet weak var collectionViewConstraintHeight: NSLayoutConstraint!
     @IBOutlet weak var imageCropViewConstraintTop: NSLayoutConstraint!
-    
+
     weak var delegate: FSAlbumViewDelegate? = nil
     
     var images: PHFetchResult<PHAsset>!
@@ -61,12 +63,19 @@ final class FSAlbumView: UIView, UICollectionViewDataSource, UICollectionViewDel
         }
 		
 		self.isHidden = false
+
+        // Set Image Crop Ratio
+        if let heightRatio = delegate?.getCropHeightRatio() {
+            imageCropViewContainer.addConstraint(NSLayoutConstraint(item: imageCropViewContainer, attribute: NSLayoutAttribute.height, relatedBy: NSLayoutRelation.equal, toItem: imageCropViewContainer, attribute: NSLayoutAttribute.width, multiplier: heightRatio, constant: 0)
+            )
+            layoutSubviews()
+        }
         
         let panGesture      = UIPanGestureRecognizer(target: self, action: #selector(FSAlbumView.panned(_:)))
         panGesture.delegate = self
         self.addGestureRecognizer(panGesture)
         
-        collectionViewConstraintHeight.constant = self.frame.height - imageCropView.frame.height - imageCropViewOriginalConstraintTop
+        collectionViewConstraintHeight.constant = self.frame.height - imageCropViewContainer.frame.height - imageCropViewOriginalConstraintTop
         imageCropViewConstraintTop.constant = 50
         dragDirection = Direction.up
         

--- a/Sources/FSAlbumView.xib
+++ b/Sources/FSAlbumView.xib
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10117" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -17,7 +21,7 @@
                     <subviews>
                         <collectionView clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="scaleToFill" showsHorizontalScrollIndicator="NO" dataMode="none" translatesAutoresizingMaskIntoConstraints="NO" id="6id-Ro-HHC">
                             <rect key="frame" x="0.0" y="450" width="400" height="150"/>
-                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                             <constraints>
                                 <constraint firstAttribute="height" constant="150" id="ofF-eS-Nvv"/>
                             </constraints>
@@ -33,7 +37,7 @@
                             </connections>
                         </collectionView>
                     </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="bottom" secondItem="6id-Ro-HHC" secondAttribute="bottom" id="H2u-OW-Xid"/>
                         <constraint firstAttribute="trailing" secondItem="6id-Ro-HHC" secondAttribute="trailing" id="fKl-55-Q4t"/>
@@ -45,22 +49,19 @@
                     <subviews>
                         <scrollView multipleTouchEnabled="YES" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="Mc5-1c-z7q" customClass="FSImageCropView" customModule="Fusuma" customModuleProvider="target">
                             <rect key="frame" x="0.0" y="0.0" width="400" height="400"/>
-                            <constraints>
-                                <constraint firstAttribute="width" secondItem="Mc5-1c-z7q" secondAttribute="height" multiplier="1:1" id="Tue-WW-idi"/>
-                            </constraints>
                         </scrollView>
                     </subviews>
-                    <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstItem="Mc5-1c-z7q" firstAttribute="leading" secondItem="90B-0c-ych" secondAttribute="leading" id="1DN-yd-Kyl"/>
                         <constraint firstAttribute="bottom" secondItem="Mc5-1c-z7q" secondAttribute="bottom" id="1Yc-V1-EBB"/>
                         <constraint firstItem="Mc5-1c-z7q" firstAttribute="top" secondItem="90B-0c-ych" secondAttribute="top" id="Jn1-QR-IAN"/>
-                        <constraint firstAttribute="width" secondItem="90B-0c-ych" secondAttribute="height" multiplier="1:1" id="coZ-5v-rE3"/>
+                        <constraint firstAttribute="width" secondItem="90B-0c-ych" secondAttribute="height" multiplier="1:1" priority="750" id="coZ-5v-rE3"/>
                         <constraint firstAttribute="trailing" secondItem="Mc5-1c-z7q" secondAttribute="trailing" id="sKD-NK-t20"/>
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstAttribute="trailing" secondItem="90B-0c-ych" secondAttribute="trailing" id="7re-q7-aoD"/>
                 <constraint firstAttribute="bottom" secondItem="9Cu-Zp-X0j" secondAttribute="bottom" id="94b-v2-S3a"/>

--- a/Sources/FSCameraView.swift
+++ b/Sources/FSCameraView.swift
@@ -19,8 +19,8 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
     @IBOutlet weak var shotButton: UIButton!
     @IBOutlet weak var flashButton: UIButton!
     @IBOutlet weak var flipButton: UIButton!
-    @IBOutlet weak var croppedAspectRatioConstraint: NSLayoutConstraint!
     @IBOutlet weak var fullAspectRatioConstraint: NSLayoutConstraint!
+    var croppedAspectRatioConstraint: NSLayoutConstraint?
     
     weak var delegate: FSCameraViewDelegate? = nil
     

--- a/Sources/FSCameraView.xib
+++ b/Sources/FSCameraView.xib
@@ -1,9 +1,13 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="10116" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="11542" systemVersion="16B2555" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+    <device id="retina4_7" orientation="portrait">
+        <adaptation id="fullscreen"/>
+    </device>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="10085"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11524"/>
         <capability name="Aspect ratio constraints" minToolsVersion="5.1"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
@@ -14,10 +18,9 @@
             <subviews>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="SZ8-Sp-jjd">
                     <rect key="frame" x="0.0" y="50" width="400" height="450"/>
-                    <color key="backgroundColor" white="0.0" alpha="1" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstAttribute="width" secondItem="SZ8-Sp-jjd" secondAttribute="height" multiplier="3:4" priority="750" id="50d-Ra-Hof"/>
-                        <constraint firstAttribute="width" secondItem="SZ8-Sp-jjd" secondAttribute="height" multiplier="1:1" priority="250" id="dsr-FI-2Hq"/>
                     </constraints>
                 </view>
                 <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="oUi-qP-Neb">
@@ -60,7 +63,7 @@
                             </connections>
                         </button>
                     </subviews>
-                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                     <constraints>
                         <constraint firstItem="o8l-Ld-Oon" firstAttribute="centerX" secondItem="oUi-qP-Neb" secondAttribute="centerX" id="2uy-UJ-fI0"/>
                         <constraint firstAttribute="trailing" secondItem="De1-Cg-kBb" secondAttribute="trailing" constant="15" id="7HT-h5-nDc"/>
@@ -72,7 +75,7 @@
                     </constraints>
                 </view>
             </subviews>
-            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
             <constraints>
                 <constraint firstAttribute="bottom" secondItem="oUi-qP-Neb" secondAttribute="bottom" id="7zn-vY-NCd"/>
                 <constraint firstAttribute="trailing" secondItem="oUi-qP-Neb" secondAttribute="trailing" id="HM7-dt-RPz"/>
@@ -85,7 +88,6 @@
             <nil key="simulatedStatusBarMetrics"/>
             <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
             <connections>
-                <outlet property="croppedAspectRatioConstraint" destination="dsr-FI-2Hq" id="dCb-jy-WZQ"/>
                 <outlet property="flashButton" destination="De1-Cg-kBb" id="vgA-Pn-IaF"/>
                 <outlet property="flipButton" destination="cf2-eo-TZZ" id="m0O-6p-tPs"/>
                 <outlet property="fullAspectRatioConstraint" destination="50d-Ra-Hof" id="6YW-vf-C0C"/>

--- a/Sources/FSImageCropView.swift
+++ b/Sources/FSImageCropView.swift
@@ -30,7 +30,7 @@ final class FSImageCropView: UIScrollView, UIScrollViewDelegate {
                 imageView.image = nil
                 return
             }
-            
+
             if !fusumaCropImage {
                 // Disable scroll view and set image to fit in view
                 imageView.frame = self.frame
@@ -42,71 +42,27 @@ final class FSImageCropView: UIScrollView, UIScrollViewDelegate {
             }
 
             let imageSize = self.imageSize ?? image.size
-            
-            if imageSize.width < self.frame.width || imageSize.height < self.frame.height {
-                
-                // The width or height of the image is smaller than the frame size
-                
-                if imageSize.width > imageSize.height {
-                    
-                    // Width > Height
-                    
-                    let ratio = self.frame.width / imageSize.width
-                    
-                    imageView.frame = CGRect(
-                        origin: CGPoint.zero,
-                        size: CGSize(width: self.frame.width, height: imageSize.height * ratio)
-                    )
-                    
-                } else {
-                    
-                    // Width <= Height
-                    
-                    let ratio = self.frame.height / imageSize.height
-                    
-                    imageView.frame = CGRect(
-                        origin: CGPoint.zero,
-                        size: CGSize(width: imageSize.width * ratio, height: self.frame.size.height)
-                    )
-                    
-                }
-                
-                imageView.center = self.center
-                
+
+            let ratioW = frame.width / imageSize.width // 400 / 1000 => 0.4
+            let ratioH = frame.height / imageSize.height // 300 / 500 => 0.6
+
+            if ratioH > ratioW {
+                imageView.frame = CGRect(
+                    origin: CGPoint.zero,
+                    size: CGSize(width: imageSize.width  * ratioH, height: frame.height)
+                )
             } else {
-
-                // The width or height of the image is bigger than the frame size
-
-                if imageSize.width > imageSize.height {
-                    
-                    // Width > Height
-                    
-                    let ratio = self.frame.height / imageSize.height
-                    
-                    imageView.frame = CGRect(
-                        origin: CGPoint.zero,
-                        size: CGSize(width: imageSize.width * ratio, height: self.frame.height)
-                    )
-                    
-                } else {
-                    
-                    // Width <= Height
-
-                    let ratio = self.frame.width / imageSize.width
-                    
-                    imageView.frame = CGRect(
-                        origin: CGPoint.zero,
-                        size: CGSize(width: self.frame.width, height: imageSize.height * ratio)
-                    )
-                    
-                }
-                
-                self.contentOffset = CGPoint(
-                    x: imageView.center.x - self.center.x,
-                    y: imageView.center.y - self.center.y
+                imageView.frame = CGRect(
+                    origin: CGPoint.zero,
+                    size: CGSize(width: frame.width, height: imageSize.height  * ratioW)
                 )
             }
-            
+
+            self.contentOffset = CGPoint(
+                x: imageView.center.x - self.center.x,
+                y: imageView.center.y - self.center.y
+            )
+
             self.contentSize = CGSize(width: imageView.frame.width + 1, height: imageView.frame.height + 1)
             
             imageView.image = image

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -80,6 +80,7 @@ public final class FusumaViewController: UIViewController {
     }
 
     public var hasVideo = false
+    public var cropHeightRatio: CGFloat = 1
 
     var mode: Mode = .camera
     public var modeOrder: FusumaModeOrder = .libraryFirst
@@ -201,9 +202,9 @@ public final class FusumaViewController: UIViewController {
         cameraShotContainer.addSubview(cameraView)
         videoShotContainer.addSubview(videoView)
         
-	titleLabel.textColor = fusumaBaseTintColor
-	titleLabel.font = fusumaTitleFont
-		
+        titleLabel.textColor = fusumaBaseTintColor
+        titleLabel.font = fusumaTitleFont
+            
 //        if modeOrder != .LibraryFirst {
 //            libraryFirstConstraints.forEach { $0.priority = 250 }
 //            cameraFirstConstraints.forEach { $0.priority = 1000 }
@@ -228,11 +229,14 @@ public final class FusumaViewController: UIViewController {
         }
         
         if fusumaCropImage {
+            let heightRatio = getCropHeightRatio()
+            cameraView.croppedAspectRatioConstraint = NSLayoutConstraint(item: cameraView.previewViewContainer, attribute: NSLayoutAttribute.height, relatedBy: NSLayoutRelation.equal, toItem: cameraView.previewViewContainer, attribute: NSLayoutAttribute.width, multiplier: heightRatio, constant: 0)
+
             cameraView.fullAspectRatioConstraint.isActive = false
-            cameraView.croppedAspectRatioConstraint.isActive = true
+            cameraView.croppedAspectRatioConstraint?.isActive = true
         } else {
             cameraView.fullAspectRatioConstraint.isActive = true
-            cameraView.croppedAspectRatioConstraint.isActive = false
+            cameraView.croppedAspectRatioConstraint?.isActive = false
         }
     }
     
@@ -315,9 +319,10 @@ public final class FusumaViewController: UIViewController {
                 
                 let targetWidth = floor(CGFloat(self.albumView.phAsset.pixelWidth) * cropRect.width)
                 let targetHeight = floor(CGFloat(self.albumView.phAsset.pixelHeight) * cropRect.height)
-                let dimension = max(min(targetHeight, targetWidth), 1024 * UIScreen.main.scale)
-                
-                let targetSize = CGSize(width: dimension, height: dimension)
+                let dimensionW = max(min(targetHeight, targetWidth), 1024 * UIScreen.main.scale)
+                let dimensionH = dimensionW * self.getCropHeightRatio()
+
+                let targetSize = CGSize(width: dimensionW, height: dimensionH)
                 
                 PHImageManager.default().requestImage(for: self.albumView.phAsset, targetSize: targetSize,
                 contentMode: .aspectFill, options: options) {
@@ -345,6 +350,9 @@ public final class FusumaViewController: UIViewController {
 }
 
 extension FusumaViewController: FSAlbumViewDelegate, FSCameraViewDelegate, FSVideoCameraViewDelegate {
+    public func getCropHeightRatio() -> CGFloat {
+        return cropHeightRatio
+    }
     
     // MARK: FSCameraViewDelegate
     func cameraShotFinished(_ image: UIImage) {

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -40,8 +40,8 @@ fileprivate func > <T : Comparable>(lhs: T?, rhs: T?) -> Bool {
 }
 
 public var fusumaBaseTintColor   = UIColor.hex("#FFFFFF", alpha: 1.0)
-public var fusumaTintColor       = UIColor.hex("#009688", alpha: 1.0)
-public var fusumaBackgroundColor = UIColor.hex("#212121", alpha: 1.0)
+public var fusumaTintColor       = UIColor.hex("#F38181", alpha: 1.0)
+public var fusumaBackgroundColor = UIColor.hex("#3B3D45", alpha: 1.0)
 
 public var fusumaAlbumImage : UIImage? = nil
 public var fusumaCameraImage : UIImage? = nil


### PR DESCRIPTION
With the setting below:
```
fusuma.cropHeightRatio = 0.6 // ratio = 10:6 
```
You can crop image with a custom ratio.

Default setting is 1 which is 1:1 (square), so it should behave the same if the setting is not set.

This PR also includes some refactoring on `FSImageCropView.swift` file.
