### PR TITLE
Add fusumaWillClosed() method to delegate.

### DIFF
--- a/Example/FusumaExample/ViewController.swift
+++ b/Example/FusumaExample/ViewController.swift
@@ -92,7 +92,10 @@ class ViewController: UIViewController, FusumaDelegate {
     }
     
     func fusumaClosed() {
-     
+        print("Called when the FusumaViewController disappeared")
+    }
+    
+    func fusumaWillClose() {
         print("Called when the close button is pressed")
     }
 

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -38,11 +38,13 @@ public protocol FusumaDelegate: class {
     // MARK: Optional
     func fusumaDismissedWithImage(_ image: UIImage, source: FusumaMode)
     func fusumaClosed()
+    func fusumaWillClosed()
 }
 
 public extension FusumaDelegate {
     func fusumaDismissedWithImage(_ image: UIImage, source: FusumaMode) {}
     func fusumaClosed() {}
+    func fusumaWillClosed() {}
 }
 
 public var fusumaBaseTintColor   = UIColor.hex("#FFFFFF", alpha: 1.0)
@@ -282,8 +284,8 @@ public class FusumaViewController: UIViewController {
     }
     
     @IBAction func closeButtonPressed(_ sender: UIButton) {
+        self.delegate?.fusumaWillClosed()
         self.dismiss(animated: true, completion: {
-            
             self.delegate?.fusumaClosed()
         })
     }


### PR DESCRIPTION
I added an optional method `fusumaWillClosed()` to `delegate`, which will work before the FusumaViewController will be hidden. This method is good to use for updating UI.
If use `fusumaClosed()` for updating UI, then the changes will be visible to the user.