### PR TITLE
Fix a scrollsToTop bug for the FSImageCropView.

### DIFF
--- a/Sources/FSImageCropView.swift
+++ b/Sources/FSImageCropView.swift
@@ -90,6 +90,7 @@ final class FSImageCropView: UIScrollView, UIScrollViewDelegate {
         self.showsVerticalScrollIndicator   = false
         self.bouncesZoom = true
         self.bounces = true
+        self.scrollsToTop = false
         
         self.delegate = self
     }


### PR DESCRIPTION
In a album view the crop view responds to the status bar tap which repositions the image in a crop view. It can happen when the user misses tapping the arrow to confirm selection and thus the user loses the set image position. It is solved by setting the scrollsToTop parameter for the crop view to false.