### PR TITLE
Adds optional delegate for image metadata

### DIFF
--- a/Example/FusumaExample/ViewController.swift
+++ b/Example/FusumaExample/ViewController.swift
@@ -53,7 +53,18 @@ class ViewController: UIViewController, FusumaDelegate {
         
         imageView.image = image
     }
-    
+
+    func fusumaImageSelected(_ image: UIImage, source: FusumaMode, metaData: ImageMetadata) {
+        print("Image mediatype: \(metaData.mediaType)")
+        print("Source image size: \(metaData.pixelWidth)x\(metaData.pixelHeight)")
+        print("Creation date: \(metaData.creationDate)")
+        print("Modification date: \(metaData.modificationDate)")
+        print("Video duration: \(metaData.duration)")
+        print("Is favourite: \(metaData.isFavourite)")
+        print("Is hidden: \(metaData.isHidden)")
+        print("Location: \(metaData.location)")
+    }
+
     func fusumaVideoCompleted(withFileURL fileURL: URL) {
         print("video completed and output to file: \(fileURL)")
         self.fileUrlLabel.text = "file output to: \(fileURL.absoluteString)"

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -36,12 +36,14 @@ public protocol FusumaDelegate: class {
     func fusumaCameraRollUnauthorized()
  
     // MARK: Optional
+    func fusumaImageSelected(_ image: UIImage, source: FusumaMode, metaData: ImageMetadata)
     func fusumaDismissedWithImage(_ image: UIImage, source: FusumaMode)
     func fusumaClosed()
     func fusumaWillClosed()
 }
 
 public extension FusumaDelegate {
+    func fusumaImageSelected(_ image: UIImage, source: FusumaMode, metaData: ImageMetadata) {}
     func fusumaDismissedWithImage(_ image: UIImage, source: FusumaMode) {}
     func fusumaClosed() {}
     func fusumaWillClosed() {}
@@ -82,6 +84,18 @@ public enum FusumaMode {
     case camera
     case library
     case video
+}
+
+public struct ImageMetadata {
+    let mediaType: PHAssetMediaType
+    let pixelWidth: Int
+    let pixelHeight: Int
+    let creationDate: Date?
+    let modificationDate: Date?
+    let location: CLLocation?
+    let duration: TimeInterval
+    let isFavourite: Bool
+    let isHidden: Bool
 }
 
 //@objc public class FusumaViewController: UIViewController, FSCameraViewDelegate, FSAlbumViewDelegate {
@@ -342,6 +356,20 @@ public class FusumaViewController: UIViewController {
                         self.dismiss(animated: true, completion: {
                             self.delegate?.fusumaDismissedWithImage(result!, source: self.mode)
                         })
+
+                        let metaData = ImageMetadata(
+                            mediaType: self.albumView.phAsset.mediaType,
+                            pixelWidth: self.albumView.phAsset.pixelWidth,
+                            pixelHeight: self.albumView.phAsset.pixelHeight,
+                            creationDate: self.albumView.phAsset.creationDate,
+                            modificationDate: self.albumView.phAsset.modificationDate,
+                            location: self.albumView.phAsset.location,
+                            duration: self.albumView.phAsset.duration,
+                            isFavourite: self.albumView.phAsset.isFavorite,
+                            isHidden: self.albumView.phAsset.isHidden)
+
+                        self.delegate?.fusumaImageSelected(result!, source: self.mode, metaData: metaData)
+
                     })
                 }
             })

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -87,27 +87,15 @@ public enum FusumaMode {
 }
 
 public struct ImageMetadata {
-    let mediaType: PHAssetMediaType
-    let pixelWidth: Int
-    let pixelHeight: Int
-    let creationDate: Date?
-    let modificationDate: Date?
-    let location: CLLocation?
-    let duration: TimeInterval
-    let isFavourite: Bool
-    let isHidden: Bool
-
-    public init(mediaType: PHAssetMediaType, pixelWidth: Int, pixelHeight: Int, creationDate: Date?, modificationDate: Date?, location: CLLocation?, duration: TimeInterval, isFavourite: Bool, isHidden: Bool) {
-        self.mediaType = mediaType
-        self.pixelHeight = pixelHeight
-        self.pixelWidth = pixelWidth
-        self.creationDate = creationDate
-        self.modificationDate = modificationDate
-        self.location = location
-        self.duration = duration
-        self.isFavourite = isFavourite
-        self.isHidden = isHidden
-    }
+    public let mediaType: PHAssetMediaType
+    public let pixelWidth: Int
+    public let pixelHeight: Int
+    public let creationDate: Date?
+    public let modificationDate: Date?
+    public let location: CLLocation?
+    public let duration: TimeInterval
+    public let isFavourite: Bool
+    public let isHidden: Bool
 }
 
 //@objc public class FusumaViewController: UIViewController, FSCameraViewDelegate, FSAlbumViewDelegate {

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -96,6 +96,18 @@ public struct ImageMetadata {
     let duration: TimeInterval
     let isFavourite: Bool
     let isHidden: Bool
+
+    public init(mediaType: PHAssetMediaType, pixelWidth: Int, pixelHeight: Int, creationDate: Date?, modificationDate: Date?, location: CLLocation?, duration: TimeInterval, isFavourite: Bool, isHidden: Bool) {
+        self.mediaType = mediaType
+        self.pixelHeight = pixelHeight
+        self.pixelWidth = pixelWidth
+        self.creationDate = creationDate
+        self.modificationDate = modificationDate
+        self.location = location
+        self.duration = duration
+        self.isFavourite = isFavourite
+        self.isHidden = isHidden
+    }
 }
 
 //@objc public class FusumaViewController: UIViewController, FSCameraViewDelegate, FSAlbumViewDelegate {


### PR DESCRIPTION
This adds an optional delegate for retrieving a gallery images metadata.   Our app requires the GPS exif but I figured the other information like video duration and original picture size could also be useful in certain circumstances.

I've also update the example to demonstrate usage.