### PR TITLE
Saves image to camera roll

### DIFF
--- a/Example/FusumaExample/ViewController.swift
+++ b/Example/FusumaExample/ViewController.swift
@@ -36,6 +36,7 @@ class ViewController: UIViewController, FusumaDelegate {
         
         fusuma.delegate = self
         fusuma.cropHeightRatio = 0.6
+        fusumaSavesImage = true
 
         self.present(fusuma, animated: true, completion: nil)
     }

--- a/Sources/FSCameraView.swift
+++ b/Sources/FSCameraView.swift
@@ -9,6 +9,7 @@
 import UIKit
 import AVFoundation
 import CoreMotion
+import Photos
 
 @objc protocol FSCameraViewDelegate: class {
     func cameraShotFinished(_ image: UIImage)
@@ -180,7 +181,14 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
         motionManager?.stopAccelerometerUpdates()
         currentDeviceOrientation = nil
     }
-    
+
+    func saveImageToCameraRoll(image: UIImage) {
+        PHPhotoLibrary.shared().performChanges({
+            PHAssetChangeRequest.creationRequestForAsset(from: image)
+
+        }, completionHandler: nil)
+    }
+
     @IBAction func shotButtonPressed(_ sender: UIButton) {
         
         guard let imageOutput = imageOutput else {
@@ -242,8 +250,17 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
                         if fusumaCropImage {
                             let resizedImage = UIImage(cgImage: imageRef!, scale: sw/iw, orientation: image.imageOrientation)
                             delegate.cameraShotFinished(resizedImage)
+
+                            if fusumaSavesImage {
+                                self.saveImageToCameraRoll(image: resizedImage)
+                            }
+
                         } else {
                             delegate.cameraShotFinished(image)
+
+                            if fusumaSavesImage {
+                                self.saveImageToCameraRoll(image: image)
+                            }
                         }
                         
                         self.session       = nil

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -66,6 +66,8 @@ public var fusumaVideoStopImage : UIImage? = nil
 
 public var fusumaCropImage: Bool = true
 
+public var fusumaSavesImage: Bool = false
+
 public var fusumaCameraRollTitle = "CAMERA ROLL"
 public var fusumaCameraTitle = "PHOTO"
 public var fusumaVideoTitle = "VIDEO"


### PR DESCRIPTION
This adds a new global variable to save the photo to the devices camera roll.  So there is no un-expected behaviour with existing apps it defaults to false.   To use set:

`fusumaSavesImage = true`