### PR TITLE
Allow manual dismissing of Fusuma

### DIFF
--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -89,7 +89,8 @@ public class FusumaViewController: UIViewController {
 
     public var hasVideo = false
     public var cropHeightRatio: CGFloat = 1
-
+    public var autoDismiss: Bool = true
+    
     var mode: FusumaMode = .camera
     public var modeOrder: FusumaModeOrder = .libraryFirst
     var willFilter = true
@@ -285,9 +286,11 @@ public class FusumaViewController: UIViewController {
     
     @IBAction func closeButtonPressed(_ sender: UIButton) {
         self.delegate?.fusumaWillClosed()
-        self.dismiss(animated: true, completion: {
-            self.delegate?.fusumaClosed()
-        })
+        if autoDismiss {
+            self.dismiss(animated: true, completion: {
+                self.delegate?.fusumaClosed()
+            })
+        }
     }
     
     @IBAction func libraryButtonPressed(_ sender: UIButton) {
@@ -339,9 +342,11 @@ public class FusumaViewController: UIViewController {
                     DispatchQueue.main.async(execute: {
                         self.delegate?.fusumaImageSelected(result!, source: self.mode)
                         
-                        self.dismiss(animated: true, completion: {
-                            self.delegate?.fusumaDismissedWithImage(result!, source: self.mode)
-                        })
+                        if self.autoDismiss {
+                            self.dismiss(animated: true, completion: {
+                                self.delegate?.fusumaDismissedWithImage(result!, source: self.mode)
+                            })
+                        }
                     })
                 }
             })
@@ -349,9 +354,11 @@ public class FusumaViewController: UIViewController {
             print("no image crop ")
             delegate?.fusumaImageSelected((view?.image)!, source: mode)
             
-            self.dismiss(animated: true, completion: {
-                self.delegate?.fusumaDismissedWithImage((view?.image)!, source: self.mode)
-            })
+            if autoDismiss {
+                self.dismiss(animated: true, completion: {
+                    self.delegate?.fusumaDismissedWithImage((view?.image)!, source: self.mode)
+                })
+            }
         }
     }
     
@@ -366,10 +373,11 @@ extension FusumaViewController: FSAlbumViewDelegate, FSCameraViewDelegate, FSVid
     func cameraShotFinished(_ image: UIImage) {
         
         delegate?.fusumaImageSelected(image, source: mode)
-        self.dismiss(animated: true, completion: {
-            
-            self.delegate?.fusumaDismissedWithImage(image, source: self.mode)
-        })
+        if autoDismiss {
+            self.dismiss(animated: true, completion: {
+                self.delegate?.fusumaDismissedWithImage(image, source: self.mode)
+            })
+        }
     }
     
     public func albumViewCameraRollAuthorized() {
@@ -385,7 +393,9 @@ extension FusumaViewController: FSAlbumViewDelegate, FSCameraViewDelegate, FSVid
     
     func videoFinished(withFileURL fileURL: URL) {
         delegate?.fusumaVideoCompleted(withFileURL: fileURL)
-        self.dismiss(animated: true, completion: nil)
+        if autoDismiss {
+            self.dismiss(animated: true, completion: nil)
+        }
     }
     
 }


### PR DESCRIPTION
This feature would allow users to control how Fusuma dismisses and be able to integrate Fusuma into a user action 'flow'. E.g. select image from fusuma => push a new UploadVC onto the nav stack

This solves the issue below:
https://github.com/ytakzk/Fusuma/issues/122


Note that I did not base this of the latest master (tag 1.0.4) as this seem to have some issues with `@obj` protocols and protocol extensions:
http://stackoverflow.com/questions/39487168/non-objc-method-does-not-satisfy-optional-requirement-of-objc-protocol
 
