### PR TITLE
Fixes constraints warning

### DIFF
--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -247,7 +247,6 @@ public class FusumaViewController: UIViewController {
                 )
             )
             
-            self.view.layoutIfNeeded()
         }
         
         if fusumaCropImage {


### PR DESCRIPTION
Removing `layoutIfNeeded()` from triggering again in `viewDidLoad`  fixes the broken constraint warnings.

I've tested manually and it seems to be consequence free.