### PR TITLE
moved changeMode method from viewDidLoad to viewDidAppear

### DIFF
--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -249,7 +249,6 @@ public class FusumaViewController: UIViewController {
             cameraView.croppedAspectRatioConstraint?.isActive = false
         }
         
-        changeMode(defaultMode)
         
     }
     
@@ -275,6 +274,9 @@ public class FusumaViewController: UIViewController {
             videoView.layoutIfNeeded()
             videoView.initialize()
         }
+        
+        changeMode(defaultMode)
+
     }
     
     public override func viewWillDisappear(_ animated: Bool) {


### PR DESCRIPTION
moved changeMode method from viewDidLoad to viewDidAppear, otherwise the bottom border line is not aligned properly with the button when loaded on an iPad