### PR TITLE
add ability to use front camera on start

### DIFF
--- a/Sources/FSCameraView.swift
+++ b/Sources/FSCameraView.swift
@@ -23,6 +23,7 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
     @IBOutlet weak var flipButton: UIButton!
     @IBOutlet weak var fullAspectRatioConstraint: NSLayoutConstraint!
     var croppedAspectRatioConstraint: NSLayoutConstraint?
+    var initialCaptureDevicePosition: AVCaptureDevicePosition = .back
     
     weak var delegate: FSCameraViewDelegate? = nil
     
@@ -76,7 +77,7 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
         for device in AVCaptureDevice.devices() {
             
             if let device = device as? AVCaptureDevice,
-                device.position == AVCaptureDevicePosition.back {
+                device.position == initialCaptureDevicePosition {
                 
                 self.device = device
                 

--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -109,6 +109,7 @@ public struct ImageMetadata {
     fileprivate var mode: FusumaMode = .library
     
     public var availableModes: [FusumaMode] = [.library, .camera]
+    public var cameraPosition = AVCaptureDevicePosition.back
 
     @IBOutlet weak var photoLibraryViewerContainer: UIView!
     @IBOutlet weak var cameraShotContainer: UIView!
@@ -293,7 +294,7 @@ public struct ImageMetadata {
             cameraView.fullAspectRatioConstraint.isActive     = true
             cameraView.croppedAspectRatioConstraint?.isActive = false
         }
-        
+        cameraView.initialCaptureDevicePosition = cameraPosition
     }
     
     override public func viewWillAppear(_ animated: Bool) {


### PR DESCRIPTION
Allow ability to set the initial camera to the front instead of the back camera in addition to the default mode or camera/library order #62 