### PR TITLE
fix initialize from availableModes

### DIFF
--- a/Sources/FusumaViewController.swift
+++ b/Sources/FusumaViewController.swift
@@ -306,7 +306,7 @@ public struct ImageMetadata {
     override public func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
         
-        if availableModes.contains(.camera) {
+        if availableModes.contains(.library) {
             
             albumView.frame = CGRect(origin: CGPoint.zero, size: photoLibraryViewerContainer.frame.size)
             albumView.layoutIfNeeded()


### PR DESCRIPTION
When specifying availableModes with. library only, the problem that the case statement is incorrect and will not work properly has been corrected.