### PR TITLE
Added guards to unwrap video connection and buffer

### DIFF
--- a/Sources/FSCameraView.swift
+++ b/Sources/FSCameraView.swift
@@ -159,12 +159,13 @@ final class FSCameraView: UIView, UIGestureRecognizerDelegate {
         }
 
         DispatchQueue.global(qos: .default).async(execute: { () -> Void in
-            let videoConnection = imageOutput.connection(with: AVMediaType.video)
+            guard let videoConnection = imageOutput.connection(with: AVMediaType.video) else { return }
 
-            imageOutput.captureStillImageAsynchronously(from: videoConnection!) { (buffer, error) -> Void in
+            imageOutput.captureStillImageAsynchronously(from: videoConnection) { (buffer, error) -> Void in
                 self.stopCamera()
 
-                guard let data = AVCaptureStillImageOutput.jpegStillImageNSDataRepresentation(buffer!),
+                guard let buffer = buffer,
+                    let data = AVCaptureStillImageOutput.jpegStillImageNSDataRepresentation(buffer),
                     let image = UIImage(data: data),
                     let cgImage = image.cgImage,
                     let delegate = self.delegate,


### PR DESCRIPTION
I recently noticed a few crashes from users whenever the shot button was pressed. I am unable to exactly pinpoint the error, but the crash logs states that it is in `shotPressed`. So I added two new guards just to make sure that the app at least don't crash when force-unwrapping the connection and buffer.

Currently the crashes has occurred on iOS 12 on devices iPhone 6s, 7 and 8.